### PR TITLE
Mejora en la selección de la Hoja del fichero ODS

### DIFF
--- a/scripts/transform-ods-to-json.js
+++ b/scripts/transform-ods-to-json.js
@@ -3,9 +3,11 @@ const XLSX = require('xlsx')
 module.exports = async function transformOdsToJson (odsFileName) {
   const workbook = XLSX.readFile(`./public/data/${odsFileName}`)
 
-  const { Sheets: { Hoja3 } } = workbook
+  const { Sheets } = workbook
 
-  const json = XLSX.utils.sheet_to_json(Hoja3)
+  const Hoja = Sheets[Object.keys(Sheets)[0]]
+
+  const json = XLSX.utils.sheet_to_json(Hoja)
 
   return json.map(element => {
     const {


### PR DESCRIPTION
Buenas Miguel,

Estuve viendo los directos en Twitch y me animado a contribuir.

Me preocupaba la desestructuración de la key “Hoja3” en la función transformOdsToJson, en las descargas de los últimos días la key sí que ha sido la “Hoja3”, pero puede que esto cambie en el caso de que este “ods” lo actualice una persona manualmente y la semana que viene sea “Hoja1” o “Hoja2” etc.

Así que he propuesto un pequeño cambio para añadir robustez, espero que sea de ayuda.

Saludos,
Javier
