### PR TITLE
Fix IB population at bbdd.json

### DIFF
--- a/public/data/bbdd.json
+++ b/public/data/bbdd.json
@@ -3,7 +3,7 @@
     "Andalucía": 8464411,
     "Aragón": 1329391,
     "Asturias": 1018784,
-    "Baleares": 5057353,
+    "Baleares": 1171543,
     "Canarias": 2175952,
     "Cantabria": 582905,
     "Castilla y Leon": 2394918,


### PR DESCRIPTION
La población de Illes Balears era errónea (tenía la de la C.Valenciana)