### PR TITLE
Añadir hook para fathom analytics

### DIFF
--- a/lib/hooks/useFathom.js
+++ b/lib/hooks/useFathom.js
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+import * as Fathom from 'fathom-client'
+
+export default function useFathom ({ ID, domains }) {
+  const router = useRouter()
+
+  useEffect(() => {
+    // initialize Fathom when the app loads
+    Fathom.load(ID, { includedDomains: [...domains] })
+
+    function onRouteChangeComplete () {
+      Fathom.trackPageview()
+    }
+
+    // record a pageview when route changes
+    router.events.on('routeChangeComplete', onRouteChangeComplete)
+
+    // unassign event listener
+    return () => {
+      router.events.off('routeChangeComplete', onRouteChangeComplete)
+    }
+  }, [])
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2784,6 +2784,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fathom-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fathom-client/-/fathom-client-3.0.0.tgz",
+      "integrity": "sha512-d0oH2SHWCMIVLbbegB7nBIjSvbqbHrZBZxIOWSVAxlJL/roL0Ah9NNb6rTIcKMlA4gov9AjWQGEcZRzlnGc3XQ=="
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "download": "8.0.0",
+    "fathom-client": "3.0.0",
     "fs-extra": "9.0.1",
     "next": "10.0.5",
     "react": "17.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,11 @@
+import useFathom from '../lib/hooks/useFathom'
+
 import '../styles/globals.css'
 
-function MyApp({ Component, pageProps }) {
+function App ({ Component, pageProps }) {
+  useFathom({ ID: 'MYEXKUNW', domains: ['covid-vacuna.app'] })
+
   return <Component {...pageProps} />
 }
 
-export default MyApp
+export default App

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,7 +46,6 @@ export default function Home ({ data, info }) {
           <meta property='twitter:url' content='https://covid-vacuna.vercel.app/' />
 
           <link rel='canonical' href='https://covid-vacuna.app' />
-          <script src='https://cdn.usefathom.com/script.js' data-site='MYEXKUNW' defer />
         </Head>
 
         <main className={styles.main}>


### PR DESCRIPTION
En el caso de que se quieran añadir futuras páginas este hook ya se encarga se hacer seguimiento sobre el propio `router` y no
hace falta instanciarlo en el <Head /> de cada página.