### PR TITLE
Clicking rows set ccaa filter

### DIFF
--- a/components/Progress.jsx
+++ b/components/Progress.jsx
@@ -7,10 +7,10 @@ const FILTERS = {
   completa: 'porcentajePoblacionCompletas'
 }
 
-export default function Progress ({ data }) {
+export default function Progress ({ totals }) {
   const locale = 'es' // get from context later
   const [filter, setFilter] = useState(FILTERS.parcial)
-  const value = data.find(({ ccaa }) => ccaa === 'Totales')[filter]
+  const value = totals[filter]
 
   return (
     <>

--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -1,13 +1,14 @@
 /* eslint-disable react/jsx-key */
-
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTable, useSortBy } from 'react-table'
 import { toDigit } from './NumberDigits.jsx'
 import { toPercentage } from './NumberPercentage.jsx'
 import styles from 'styles/Table.module.css'
 
-export default function Table ({ data }) {
+export default function Table ({ data, setFilter }) {
   const locale = 'es'
+
+  const handleRowClick = useCallback(row => () => setFilter(row.original.ccaa), [])
 
   const tableData = useMemo(
     () => data.map(row => {
@@ -111,7 +112,7 @@ export default function Table ({ data }) {
           {rows.map(row => {
             prepareRow(row)
             return (
-              <tr {...row.getRowProps()} className={row.id === '19' ? styles.totales : ''}>
+              <tr {...row.getRowProps()} className={row.id === '19' ? styles.totales : ''} onClick={handleRowClick(row)}>
                 {row.cells.map(cell => {
                   return (
                     <td {...cell.getCellProps()}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,6 @@
 /* global fetch */
+import { useMemo, useState } from 'react'
+
 import Head from 'next/head'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -23,7 +25,11 @@ import {
 import normalizeChartData from 'components/ProgressChart/utils/normalize-data'
 
 export default function Home ({ contributors, data, info, chartDatasets }) {
-  const totals = data.find(({ ccaa }) => ccaa === 'Totales')
+  const [filter, setFilter] = useState('Totales')
+
+  const totals = useMemo(() => data.find(({ ccaa }) => ccaa === filter), [
+    filter
+  ])
 
   return (
     <>
@@ -34,7 +40,7 @@ export default function Home ({ contributors, data, info, chartDatasets }) {
       <div className={styles.container}>
         <main className={styles.main}>
           <h1 className={styles.title}>
-            Vacunación COVID-19 en España
+            Vacunación COVID-19 en {filter === 'Totales' ? 'España' : filter}
           </h1>
           <small className={styles.description}>
             Datos actualizados <TimeAgo timestamp={info.lastModified} />. Fuente: <a href='https://www.mscbs.gob.es/profesionales/saludPublica/ccayes/alertasActual/nCov/vacunaCovid19.htm'>Ministerio de Sanidad</a>
@@ -154,7 +160,7 @@ export default function Home ({ contributors, data, info, chartDatasets }) {
             </div>
           </div>
 
-          <Progress data={data} />
+          <Progress totals={totals} />
 
           <a className={styles.download} download href='/data/latest.json'>
             <Image
@@ -183,7 +189,7 @@ export default function Home ({ contributors, data, info, chartDatasets }) {
           Por comunidades autónomas
         </h2>
 
-        <Table data={data} />
+        <Table data={data} setFilter={setFilter} />
 
         <h2 className={styles.subtitle}>
           Evolución de dosis entregadas


### PR DESCRIPTION
He hecho clicables las filas de la tabla para actualizar los totales. Se actualizan los datos mostrados y el título (España si no hay filtro o el nombre de la comunidad autónoma en cualquier otro caso.

En el componente Progress se estaba realizando el mismo filtrado de datos que ya se hacía en Home, he modificado eso para que solo se haga en Home y le pase ya la prop calculada a Progress. De esta forma al filtrar cliclando en la tabla también se ve afectada la barra de progreso.

Gracias por todo, espero que este pequeño aporte te guste!