### PR TITLE
Cambiar formato del valor yaxis a exponencial

### DIFF
--- a/components/ProgressChart/styles/ProgressChart.module.css
+++ b/components/ProgressChart/styles/ProgressChart.module.css
@@ -9,7 +9,7 @@
   border-radius: 8px;
   border: 2px solid #111;
   margin: 1rem 0 3rem;
-  padding: 20px 1.5rem 1.5rem;
+  padding-right: 3rem;
 }
 
 .chartTooltip {

--- a/components/ProgressChart/ticks/index.jsx
+++ b/components/ProgressChart/ticks/index.jsx
@@ -18,6 +18,9 @@ export function CustomXTick ({ x, y, payload }) {
 }
 
 export function CustomYTick ({ x, y, payload }) {
+  const exponentFormatValue = payload.value.toExponential(0)
+  const omitZero = payload.value === 0 ? '' : exponentFormatValue
+
   return (
     <g transform={`translate(${x},${y})`}>
       <text
@@ -29,7 +32,7 @@ export function CustomYTick ({ x, y, payload }) {
         textAnchor='end'
         fill='var(--text-subtitle-color)'
       >
-        {new Intl.NumberFormat('es-ES').format(payload.value)}
+        {omitZero}
       </text>
     </g>
   )

--- a/components/ProgressChart/ticks/index.jsx
+++ b/components/ProgressChart/ticks/index.jsx
@@ -19,6 +19,7 @@ export function CustomXTick ({ x, y, payload }) {
 
 export function CustomYTick ({ x, y, payload }) {
   const omitZero = payload.value === 0 ? '' : payload.value
+  const localValue = new Intl.NumberFormat('es-ES').format(omitZero)
 
   return (
     <g transform={`translate(${x},${y})`}>
@@ -31,7 +32,7 @@ export function CustomYTick ({ x, y, payload }) {
         textAnchor='end'
         fill='var(--text-subtitle-color)'
       >
-        {omitZero}
+        {localValue}
       </text>
     </g>
   )

--- a/components/ProgressChart/ticks/index.jsx
+++ b/components/ProgressChart/ticks/index.jsx
@@ -18,8 +18,7 @@ export function CustomXTick ({ x, y, payload }) {
 }
 
 export function CustomYTick ({ x, y, payload }) {
-  const exponentFormatValue = payload.value.toExponential(0)
-  const omitZero = payload.value === 0 ? '' : exponentFormatValue
+  const omitZero = payload.value === 0 ? '' : payload.value
 
   return (
     <g transform={`translate(${x},${y})`}>

--- a/components/ProgressChart/tooltips/index.jsx
+++ b/components/ProgressChart/tooltips/index.jsx
@@ -1,17 +1,28 @@
 import styles from '../styles/ProgressChart.module.css'
 
-function EnhanceText ({ children }) {
-  return <b style={{ color: 'var(--text-subtitle-color)' }}>{children}</b>
+function formatNumberToLocale (payload, locale) {
+  if (!payload) return
+
+  const { value } = payload.pop()
+
+  const num = new Intl.NumberFormat(locale)
+  return num.format(value)
+}
+
+function Bold ({ text }) {
+  return <b style={{ color: 'var(--text-subtitle-color)' }}>{text}</b>
 }
 
 export function DosisAdministradasTooltip ({ active, payload, label }) {
   if (!active) return null
 
+  const value = formatNumberToLocale(payload, 'es-ES')
+
   return (
     <div className={styles.chartTooltip}>
       <p>
-        A día <EnhanceText>{label}</EnhanceText> se han administrado{' '}
-        <EnhanceText>{payload?.pop().value}</EnhanceText> dosis.
+        A día <Bold text={label} /> se han administrado{' '}
+        <Bold text={value} /> dosis.
       </p>
     </div>
   )
@@ -20,11 +31,13 @@ export function DosisAdministradasTooltip ({ active, payload, label }) {
 export function DosisEntregadasTooltip ({ active, payload, label }) {
   if (!active) return null
 
+  const value = formatNumberToLocale(payload, 'es-ES')
+
   return (
     <div className={styles.chartTooltip}>
       <p>
-        A día <EnhanceText>{label}</EnhanceText> se han entregado{' '}
-        <EnhanceText>{payload?.pop().value}</EnhanceText> dosis.
+        A día <Bold text={label} /> se han entregado{' '}
+        <Bold text={value} /> dosis.
       </p>
     </div>
   )


### PR DESCRIPTION
* Se añade un formateo para representar exponencialmente los valores
de 6 cifras en las gráficas y así ganar un poco de espacio en el margen.