### PR TITLE
Matching link styles

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -292,6 +292,7 @@ export default function Home ({ contributors, data, info, chartDatasets }) {
         <ul>
           <li>
             <a
+              className={styles.news}
               target='_blank'
               rel='noreferrer'
               href='https://www.20minutos.es/noticia/4552926/0/lanzan-una-web-con-datos-del-gobierno-que-permite-ver-como-avanza-en-espana-la-vacunacion-contra-el-coronavirus/'
@@ -302,6 +303,7 @@ export default function Home ({ contributors, data, info, chartDatasets }) {
           </li>
           <li>
             <a
+              className={styles.news}
               target='_blank'
               rel='noreferrer'
               href='https://www.meneame.net/m/actualidad/web-revisar-estado-progreso-vacunacion-covid-19-espana'

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -75,6 +75,16 @@
   border-bottom: 1px dashed #09f;
 }
 
+.news {
+  color: #333;
+  border-bottom: 1px dashed #ddd;
+}
+
+.news:hover {
+  color: #555;
+  border-bottom: 1px dashed #09f;
+}
+
 .card {
   background: #ffffff;
   border-radius: 8px;


### PR DESCRIPTION
Los links de los enlaces a noticias no tenían el mismo estilo.
Así es más fácil reconocer links, son más perceptibles ahora.