### PR TITLE
sortBy column table and totals always on bottom fixed

### DIFF
--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -16,33 +16,17 @@ export default function Table ({ data, filter, setFilter }) {
     [filter, setFilter]
   )
 
+  const formatDigit = number => toDigit({ locale, number })
+  const formatPercentage = number => toPercentage({ locale, number })
+
   const tableData = useMemo(
     () => data.map(row => {
       const {
-        dosisAdministradas,
-        dosisEntregadas,
-        dosisEntregadasModerna,
-        dosisEntregadasPfizer,
-        dosisPautaCompletada,
-        porcentajeEntregadas,
-        porcentajePoblacionAdministradas,
-        porcentajePoblacionCompletas,
         ...rest
       } = row
 
-      const formatDigit = number => toDigit({ locale, number })
-      const formatPercentage = number => toPercentage({ locale, number })
-
       return {
-        ...rest,
-        dosisAdministradas: formatDigit(dosisAdministradas),
-        dosisEntregadas: formatDigit(dosisEntregadas),
-        dosisEntregadasModerna: formatDigit(dosisEntregadasModerna),
-        dosisEntregadasPfizer: formatDigit(dosisEntregadasPfizer),
-        dosisPautaCompletada: formatDigit(dosisPautaCompletada),
-        porcentajeEntregadas: formatPercentage(porcentajeEntregadas),
-        porcentajePoblacionAdministradas: formatPercentage(porcentajePoblacionAdministradas),
-        porcentajePoblacionCompletas: formatPercentage(porcentajePoblacionCompletas)
+        ...rest
       }
     }), []
   )
@@ -51,45 +35,53 @@ export default function Table ({ data, filter, setFilter }) {
     () => [
       {
         Header: '',
-        accessor: 'ccaa'
+        accessor: 'ccaa',
+        format: (ccaa) => ccaa
       },
       {
         Header: 'Dosis entregadas',
-        accessor: 'dosisEntregadas'
+        accessor: 'dosisEntregadas',
+        format: formatDigit
       },
       {
         Header: 'Dosis administradas',
-        accessor: 'dosisAdministradas'
+        accessor: 'dosisAdministradas',
+        format: formatDigit
       },
       {
         Header: '% sobre entregadas',
-        accessor: 'porcentajeEntregadas'
+        accessor: 'porcentajeEntregadas',
+        format: formatPercentage
       },
       {
         Header: '% población vacunada',
-        accessor: 'porcentajePoblacionAdministradas'
+        accessor: 'porcentajePoblacionAdministradas',
+        format: formatPercentage
       },
       {
         Header: 'Pauta completa',
         accessor: 'dosisPautaCompletada',
-        format: 'digit'
+        format: formatDigit
       },
       {
         Header: '% población totalmente vacunada',
         accessor: 'porcentajePoblacionCompletas',
-        format: 'percentatge'
+        format: formatPercentage
       }
     ],
     []
   )
 
-  const {
+  let {
     getTableProps,
     getTableBodyProps,
     headerGroups,
     rows,
     prepareRow
   } = useTable({ columns, data: tableData }, useSortBy)
+
+  // totales siempre en la ultima fila
+  rows = [...rows.filter(row => row.id !== '19'), rows.find(row => row.id === '19')]
 
   return (
     <div className={styles.container}>
@@ -123,7 +115,7 @@ export default function Table ({ data, filter, setFilter }) {
                 {row.cells.map(cell => {
                   return (
                     <td {...cell.getCellProps()}>
-                      {cell.render('Cell')}
+                      {cell.column.format(cell.value)}
                     </td>
                   )
                 })}

--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -22,10 +22,16 @@ export default function Table ({ data, filter, setFilter }) {
   const tableData = useMemo(
     () => data.map(row => {
       const {
+        porcentajeEntregadas,
+        porcentajePoblacionAdministradas,
+        porcentajePoblacionCompletas,
         ...rest
       } = row
 
       return {
+        porcentajeEntregadas: porcentajeEntregadas.toFixed(4),
+        porcentajePoblacionAdministradas: porcentajePoblacionAdministradas.toFixed(4),
+        porcentajePoblacionCompletas: porcentajePoblacionCompletas.toFixed(4),
         ...rest
       }
     }), []


### PR DESCRIPTION
he arreglado el problema del ordenamiento llevando el format al momento del renderizado. La fila totales se muestra ahora siempre en ultimo lugar aunque se ordene, (siempre permanece abajo)

issue relacionada: #7 