### PR TITLE
Fix schemeColorSwitcher position on change to dark and light mode

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -44,7 +44,7 @@ export default function Home ({ contributors, data, info, chartDatasets }) {
         <link rel='manifest' href='/manifest.json' />
         <meta name='theme-color' content='#d2effd' />
       </Head>
-      <div className={styles.container}>
+      <div id='container' className={styles.container}>
         <main className={styles.main}>
           <h1 className={styles.title}>
             Vacunación COVID-19 en {filter === 'Totales' ? 'España' : filter}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,6 @@
 :root {
   --app-background-color: #fefefe;
-  --app-background: 
+  --app-background:
     radial-gradient(#cdd0ff 1px, transparent 0),
     radial-gradient(#cdd0ff 1px,#fefefe 0);
 
@@ -31,7 +31,7 @@ html[scheme='light-mode'] body {
     radial-gradient(#cdd0ff 1px, transparent 0),
     radial-gradient(#cdd0ff 1px,#fefefe 0);
 }
-html[scheme='light-mode'] #__next {
+html[scheme='light-mode'] #container {
   filter: invert(0) hue-rotate(0deg);
 }
 
@@ -45,7 +45,7 @@ html[scheme='dark-mode'] body {
     radial-gradient(#15155a 1px, #111 0),
     radial-gradient(#15155a 1px,#111 0);
 }
-html[scheme='dark-mode'] #__next {
+html[scheme='dark-mode'] #container {
   filter: invert(1) hue-rotate(180deg);
 }
 


### PR DESCRIPTION
Este Pull Request corrige la incidencia #64.
Al parecer había un problema con estos selectores de CSS:
```
html[scheme='dark-mode'] #__next{
  filter: invert(1) hue-rotate(180deg);
}

html[scheme='light-mode'] #__next{
  filter: invert(0) hue-rotate(0deg);
}
```
La verdad es que no sé explicar muy bien porque se ha arreglado (espero que alguien me lo pueda explicar) pero me he inspirado [este enlace]( https://www.sitepoint.com/community/t/ms-filter-problems-while-using-position-absolute/73137/2)

He añadido un id="container" a un div hijo del `<div id="__next"></div>` y le he aplicado el filter a este nuevo id, de esta manera el schemeColorSwitcher se mantiene sticky

Si tienes cualquier duda házmelo saber y, si no te convence el PR sin problema lo descartamos ;)
PD: A ver si alguien nos puede dar explicación de esta issue.

Gracias.