### PR TITLE
Corrección traducciones en headers de tabla

### DIFF
--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -99,7 +99,7 @@ export default function Table ({ data, filter, setFilter, reportFound }) {
         format: formatPercentage
       }
     ],
-    []
+    [translate]
   )
 
   let {


### PR DESCRIPTION
Hola Midu!!, me he fijado que en las tablas al cambiar la traducción los headers no se están modificando al idioma correctamente, aunque en los json sí existen dichas traducciones. Te mando PR (mas cortita imposible)  para que le des un vistazo y si te parece hacer el merge.

Saludos!!