### PR TITLE
spreading locale from useLocale in the Prevision component

### DIFF
--- a/components/Prevision.jsx
+++ b/components/Prevision.jsx
@@ -30,7 +30,7 @@ const points = [{
 }]
 
 export default function Progress ({ totals }) {
-  const locale = useLocale()
+  const { locale } = useLocale()
   const translate = useTranslate()
   const intl = new Intl.DateTimeFormat(locale, dateTimeFormatOptions)
 


### PR DESCRIPTION
en el componente Prevision se estaba accediendo y pasando el objeto entero de useLocale, he arreglado eso haciendo el spread