### PR TITLE
ChartToolTip fix css

### DIFF
--- a/components/ProgressChart/styles/ProgressChart.module.css
+++ b/components/ProgressChart/styles/ProgressChart.module.css
@@ -18,4 +18,6 @@
   border: 2px solid var(--text-subtitle-color);
   padding: 0 10px;
   border-radius: 8px;
+  text-align: center;
+  width: 10em;
 }


### PR DESCRIPTION
## ERROR
En dispositivos móviles el tooltip al mostrarse todo el progreso en una sola la línea de un día concreto hace que se salga de la pantalla o que se reescale la página.

![image](https://user-images.githubusercontent.com/24817636/106208723-18a6c900-61c4-11eb-991e-cc0d5036fbdc.png)
## SOLUCIÓN
Se ha modificado el tamaño y centrado el texto para que sea más fácil la lectura.