### PR TITLE
Corrección alineación vertical porcentaje.

### DIFF
--- a/styles/Progress.module.css
+++ b/styles/Progress.module.css
@@ -56,6 +56,7 @@
   color: #555;
   content: attr(data-value);
   font-size: 1.5rem;
+  line-height: 1.5rem;
   right: 8px;
   top: 12px;
   position: absolute;


### PR DESCRIPTION
Poniendo el line-height igual que el font-size, visualmente el porcentaje se muestra centrado verticalmente con respecto al espacio disponible.