### PR TITLE
Fix para el estilo del porcentaje del Progress

### DIFF
--- a/components/Progress.jsx
+++ b/components/Progress.jsx
@@ -39,8 +39,8 @@ export default function Progress ({ totals }) {
           </label>
         </div>
 
-        <section data-value={toPercentage({ locale, number: value })}>
-          <progress max='100' value={value * 100} />
+        <section>
+          <progress max='100' value={value * 100} data-value={toPercentage({ locale, number: value })} />
         </section>
       </form>
     </>

--- a/styles/Progress.module.css
+++ b/styles/Progress.module.css
@@ -32,8 +32,19 @@
 }
 
 .progress progress {
+  position: relative;
   margin-bottom: 2rem;
   margin-top: .5rem;
+}
+
+.progress progress::before {
+  color: #555;
+  content: attr(data-value);
+  font-size: 1.5rem;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  position: absolute;
 }
 
 .progress progress[value] {
@@ -46,19 +57,6 @@
   overflow: hidden;
   width: 100%;
   height: 36px;
-}
-
-.progress section {
-  position: relative;
-}
-
-.progress section::before {
-  color: #555;
-  content: attr(data-value);
-  font-size: 1.5rem;
-  right: 8px;
-  top: 12px;
-  position: absolute;
 }
 
 .progress progress[value]::-webkit-progress-bar {


### PR DESCRIPTION
Me he dado cuenta que el porcentaje no se ve muy centrado verticalmente y quedaba un poco raro a la vista. Esta PR básicamente sirve para asegurarnos que esta centrado siempre en la progress bar 😀.