### PR TITLE
Corrección de estilos de las boxes de prevision en mobile

### DIFF
--- a/components/Prevision.jsx
+++ b/components/Prevision.jsx
@@ -29,7 +29,7 @@ const points = [{
   percentage: 100
 }]
 
-export default function Progress ({ totals }) {
+export default function Prevision ({ totals }) {
   const { locale } = useLocale()
   const translate = useTranslate()
   const intl = new Intl.DateTimeFormat(locale, dateTimeFormatOptions)
@@ -65,7 +65,6 @@ export default function Progress ({ totals }) {
           gap: 32px;
           grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
           justify-content: center;
-          justify-items: center;
           place-content: center;
           margin-bottom: 4rem;
           max-width: 1000px;


### PR DESCRIPTION
En primer lugar cambie el nombre del componente de Progress a Prevision, ya que había otro componente Progress y puede crear confusión a la hora de debugear.

También cambie el estilo de las boxes en mobile para ganar en coherencia visual respecto a las demás que utilizan el mismo formato de sombra.