### PR TITLE
Fix de algunos errores gramaticales y sintácticos

### DIFF
--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -9,8 +9,8 @@
     },
     "home": {
       "tituloPricipal": "Vacunació COVID-19 en",
-      "datosActualizados": "dades actualitzades",
-      "fuente": "font:",
+      "datosActualizados": "Dades actualitzades",
+      "fuente": "Font:",
       "ministerioDeSanidad": "Ministeri de Sanitat",
       "mostrarReporteFecha": "Mostrar dades a data",
       "seleccionarFecha": "Seleccionar data",
@@ -23,7 +23,7 @@
       "poblacionVacunada": "% població vacunada",
       "pautaCompleta": "Pauta completa",
       "poblacionTotalmenteVacunada": "% població totalment vacunada",
-      "evolucionDosisEntregadas": "Evolució de dosi lliurades",
+      "evolucionDosisEntregadas": "Evolució de dosis lliurades",
       "evolucionDosisAdministradas": "Evolució de dosis administrades",
       "fuenteDatosEnlacesInteres": "Fonts de dades i enllaços d'interès",
       "fuente1": "Estratègia de Vacunació COVID-19 a Espanya",
@@ -45,7 +45,7 @@
         "pfizerLogo": "Pfizer Logo",
         "modernaLogo": "moderna Logo",
         "vacunasAdministradas": "Vacunes administrades a Espanya",
-        "dosisCompletas": "Dosi completes subministrades",
+        "dosisCompletas": "Dosis completes subministrades",
         "descargarDatos": "descarregar dades",
         "incrustarDatos": "Incrusta dades en una pàgina web",
         "graficaSubiendo": "gràfica pujant",
@@ -64,8 +64,8 @@
       "noDatos": "No disposem de dades per a aquesta data."
     },
     "terminos": {
-      "dosisDistribuidas": "dosi distribuïdes",
-      "dosisAdministradas": "dosis administrades",
+      "dosisDistribuidas": "Dosis distribuïdes",
+      "dosisAdministradas": "Dosis administrades",
       "sobreDistribuidas": "% sobre distribuïdes",
       "personasConPautaCompleta": "Persones amb pauta completa",
       "sobreAdministradas": "% sobre administrades"

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -58,8 +58,8 @@
       }
     },
     "progress": {
-      "verPoblacionVacunada": "Veure població vacunada",
-      "verPoblacionConPauta": "Veure població amb pauta completa",
+      "verPoblacionVacunada": "Població vacunada",
+      "verPoblacionConPauta": "Població amb pauta completa",
       "estimacionPoblacionVacunada": "Estimació població vacunada",
       "noDatos": "No disposem de dades per a aquesta data."
     },

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -59,8 +59,8 @@
         }
     },
     "progress": {
-        "verPoblacionVacunada": "Ver población vacunada",
-        "verPoblacionConPauta": "Ver población con pauta completa",
+        "verPoblacionVacunada": "Población vacunada",
+        "verPoblacionConPauta": "Población con pauta completa",
         "estimacionPoblacionVacunada": "Estimación población vacunada",
         "noDatos": "No disponemos de datos para esa fecha."
     },

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -58,8 +58,8 @@
       }
     },
     "progress": {
-      "verPoblacionVacunada": "Ikusi txertatutako populazioa",
-      "verPoblacionConPauta": "Ikusi populazioa jarraibide osoekin",
+      "verPoblacionVacunada": "Txertatutako populazioa",
+      "verPoblacionConPauta": "Populazioa jarraibide osoekin",
       "estimacionPoblacionVacunada": "Txertatutako biztanleriaren estimazioa",
       "noDatos": "Ez dugu data horretarako daturik."
     },

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -58,8 +58,8 @@
       }
     },
     "progress": {
-      "verPoblacionVacunada": "Ver poboación vacinada",
-      "verPoblacionConPauta": "Ver poboación con directrices completas",
+      "verPoblacionVacunada": "Poboación vacinada",
+      "verPoblacionConPauta": "Poboación con directrices completas",
       "estimacionPoblacionVacunada": "Estimación da poboación vacinada",
       "noDatos": "Non dispoñemos de datos para esa data."
     },


### PR DESCRIPTION
En esta pequeña aportación he modificado 2 cosas:

1.- Errores gramaticales
- Mayúsculas en algunas palabras
- Cambiar Dosi por Dosis para mantener la consistencia

2.- Eliminar 'Ver' en los checkbox para el progressbar porque es redundante y ya se sobreentiende que es para ver ese tipo de población. Si estoy equivocado @midudev coméntamelo y lo dejo con el 'Ver' de nuevo.