### PR TITLE
Progress module: Add mouse interaction for labels

### DIFF
--- a/styles/Progress.module.css
+++ b/styles/Progress.module.css
@@ -9,6 +9,13 @@
   margin-right: 1rem;
   display: flex;
   align-items: center;
+  border-radius: 10px;
+  cursor: pointer;
+  padding: 6px;
+}
+
+.progress label:hover {
+  background-color: #d2effd;
 }
 
 .progress label input[type="radio"] {
@@ -19,6 +26,7 @@
   box-shadow: rgb(210, 239, 253) 4px 4px;
   margin-right: 8px;
   padding: 6px;
+  outline: 0;
 }
 
 .progress label input[type="radio"]:checked {


### PR DESCRIPTION
Cambio atómico. He editado el CSS de las labels para que se puedan seleccionar cómodamente con un hover y he ocultado el outline en el checkbox. 🙂

<img width="1068" alt="Captura de pantalla 2021-01-30 a las 23 02 30" src="https://user-images.githubusercontent.com/2787135/106395101-b686d780-6400-11eb-8d7d-abc57e975422.png">
<img width="1052" alt="Captura de pantalla 2021-01-31 a las 2 06 31" src="https://user-images.githubusercontent.com/2787135/106395108-bd154f00-6400-11eb-8be7-3294655684b8.png">
