### PR TITLE
actualizado Prevision.jsx

### DIFF
--- a/components/Prevision.jsx
+++ b/components/Prevision.jsx
@@ -4,14 +4,18 @@ import { useTranslate } from 'hooks/useTranslate'
 const START_DATA_VACCINATION = '01/04/2021'
 const MILISECONDS_DAY = 1000 * 60 * 60 * 24
 const dateTimeFormatOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+const DAYS_BETWEEN_FIRST_AND_SECOND = 28;
 
 const getDaysFromStartVaccination = () => {
   return (new Date().getTime() - new Date(START_DATA_VACCINATION).getTime()) / MILISECONDS_DAY
 }
 
 const getDaysToAchievePercentage = (percentageGoal, actualPercentage) => {
-  return getDaysFromStartVaccination() * percentageGoal / (actualPercentage * 100)
-}
+  return (
+    (getDaysFromStartVaccination() * percentageGoal) / (actualPercentage * 100) +
+    DAYS_BETWEEN_FIRST_AND_SECOND
+  );
+};
 
 const addDaysToInitialData = (days) => {
   const initialData = new Date(START_DATA_VACCINATION).getTime() + (days * MILISECONDS_DAY)
@@ -34,7 +38,11 @@ export default function Progress ({ totals }) {
   const translate = useTranslate()
   const intl = new Intl.DateTimeFormat(locale, dateTimeFormatOptions)
 
-  const getDays = days => getDaysToAchievePercentage(days, totals.porcentajePoblacionCompletas)
+  const getDays = (days) =>
+    getDaysToAchievePercentage(
+      days,
+      totals.porcentajePoblacionAdministradas - totals.porcentajePoblacionCompletas
+    );
 
   return (
     <>


### PR DESCRIPTION
Se actualiza la previsión de días que faltan para finalizar la vacunacion. Se tiene en consideración el ritmo de la primera dosis y se le añade el número de días entre la primera y la segunda. En teoría si el ritmo se mantuviera la vacunación terminaría 28 días después de terminar la primera dosis (momento en el que darías la segunda dosis a esos vacunados

Ahora quedaría más cercano a la realidad

![image](https://user-images.githubusercontent.com/15011687/106493967-1e4d2900-64ba-11eb-8a89-7daabd97fe10.png)
