### PR TITLE
Eliminar la dependencia con fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "d3-geo": "2.0.1",
     "download": "8.0.0",
     "fathom-client": "3.0.0",
-    "fs-extra": "9.1.0",
     "next": "10.0.5",
     "next-compose-plugins": "2.2.1",
     "next-images": "1.7.0",

--- a/scripts/download-covid-vaccine-today-status.js
+++ b/scripts/download-covid-vaccine-today-status.js
@@ -1,7 +1,7 @@
 // https://www.mscbs.gob.es/profesionales/saludPublica/ccayes/alertasActual/nCov/documentos/Informe_Comunicacion_20210119.ods
 
 const download = require('download')
-const fs = require('fs-extra')
+const fs = require('fs')
 const transformOdsToJson = require('./transform-ods-to-json')
 const getNameReports = require('./get-everything-name-reports')
 
@@ -23,10 +23,10 @@ download(url, 'public/data', { filename })
     const json = await transformOdsToJson(filename)
     const jsonFileName = filename.replace('.ods', '.json')
 
-    await fs.writeJson(`./public/data/${jsonFileName}`, json)
+    await fs.promises.writeFile(`./public/data/${jsonFileName}`, JSON.stringify(json))
     await getNameReports()
-    await fs.copyFile(`./public/data/${jsonFileName}`, './public/data/latest.json')
-    await fs.writeJson('./public/data/info.json', { lastModified: +new Date() })
+    await fs.promises.copyFile(`./public/data/${jsonFileName}`, './public/data/latest.json')
+    await fs.promises.writeFile('./public/data/info.json', JSON.stringify({ lastModified: +new Date() }))
   })
   .catch(err => {
     console.error(`${url} can't be downloaded. Error:`)

--- a/scripts/fetch-old-ods-data.js
+++ b/scripts/fetch-old-ods-data.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const download = require('download')
 const transformOdsToJson = require('./transform-ods-to-json')
 
@@ -11,7 +11,7 @@ const downloadFile = (url, filename) => {
       const json = await transformOdsToJson(filename)
       const jsonFileName = filename.replace('.ods', '.json')
 
-      await fs.writeJson(`./public/data/${jsonFileName}`, json)
+      await fs.promises.writeFile(`./public/data/${jsonFileName}`, JSON.stringify(json))
     })
     .catch(() => {
       console.error(`${url} can't be downloaded. Error:`)

--- a/scripts/get-everything-name-reports.js
+++ b/scripts/get-everything-name-reports.js
@@ -1,13 +1,13 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 
 const ignoredFiles = ['bbdd', 'info', 'latest', 'reports']
 
 module.exports = async () => {
-  const files = await fs.readdir('./public/data').catch(error => console.error(error))
+  const files = await fs.promises.readdir('./public/data').catch(error => console.error(error))
   const json = files.filter(el =>
     !ignoredFiles.includes(el.replace('.json', '')) && el.includes('.json')
   )
   const reports = json.map(el => el.replace('.json', ''))
 
-  await fs.writeJson('./public/data/reports.json', reports)
+  await fs.promises.writeFile('./public/data/reports.json', JSON.stringify(reports))
 }


### PR DESCRIPTION
Para el uso que se hace en los scripts del módulo fs-extra, nos ahorraríamos la dependencia usando módulos y funciones
nativas de node.

Para convertir json a string podemos parsearlo con JSON.stringify. A su vez, para leer directorios o escribir archivos con
promesas podemos usar el módulo nativo "fs" de node.