### PR TITLE
Mejora el formato de las fechas en el selector de reportes

### DIFF
--- a/components/Select.jsx
+++ b/components/Select.jsx
@@ -1,20 +1,24 @@
 import styles from 'styles/Select.module.css'
 import { useTranslate } from 'hooks/useTranslate'
+import { useLocale } from 'hooks/useLocale'
+
+const REPORT_DATE_REGEXP = /(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})/
+
+const toDate = (value) => {
+  const { year, month, day } = value.match(REPORT_DATE_REGEXP).groups
+  return new Date(parseInt(year), parseInt(month) - 1, parseInt(day))
+}
+
+const formatDate = ({ locale, value }) => {
+  const date = toDate(value)
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric', month: '2-digit', day: '2-digit'
+  }).format(date)
+}
 
 export default function Select ({ data, onChange }) {
+  const { locale } = useLocale()
   const translate = useTranslate()
-  const normalizedDate = (date) => {
-    let dateFormat = ''
-    for (let i = 0; i < date.length; i++) {
-      dateFormat = dateFormat + date[i]
-      if (i === 3) {
-        dateFormat = dateFormat + '/'
-      } if (i === 5) {
-        dateFormat = dateFormat + '/'
-      }
-    }
-    return dateFormat
-  }
 
   return (
     <>
@@ -30,7 +34,7 @@ export default function Select ({ data, onChange }) {
             {data &&
               data.map((date) => (
                 <option key={date} value={date}>
-                  {normalizedDate(date)}
+                  {formatDate({ locale, value: date })}
                 </option>
               ))}
           </select>


### PR DESCRIPTION
Mejora el formato de las fechas en el selector de reportes en base al locale.

Antes:
![before](https://user-images.githubusercontent.com/3719969/107574090-34f42e00-6be6-11eb-975a-5f56d2b94a9d.png)

Después:
![after](https://user-images.githubusercontent.com/3719969/107574105-39b8e200-6be6-11eb-8a50-02d385a2dfbe.png)

Enhorabuena por el proyecto! 👌