### PR TITLE
Arreglado el título en catalán y otros idiomas

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -63,7 +63,7 @@ export default function Home ({ contributors, data, info, reports, chartDatasets
       <div id='container' className={styles.container}>
         <main className={styles.main}>
           <h1 className={styles.title}>
-            {translate.home.tituloPricipal} {filter === 'Totales' ? 'España' : filter}
+            {translate.home.tituloPricipal}
           </h1>
           <small className={styles.description}>
             {translate.home.datosActualizados} <TimeAgo timestamp={info.lastModified} />.

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -8,7 +8,7 @@
       "darkAriaLabel": "Una lluna amb ulls sospitosos que sembla que està tramant alguna cosa fotuda"
     },
     "home": {
-      "tituloPricipal": "Vacunació COVID-19 a",
+      "tituloPricipal": "Vacunació COVID-19 a Espanya",
       "datosActualizados": "Dades actualitzades",
       "fuente": "Font:",
       "ministerioDeSanidad": "Ministeri de Sanitat",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -9,7 +9,7 @@
 
     },
     "home": {
-        "tituloPricipal": "Vacunación COVID-19 en",
+        "tituloPricipal": "Vacunación COVID-19 en España",
         "datosActualizados": "Datos actualizados",
         "fuente": "Fuente:",
         "ministerioDeSanidad": "Ministerio de Sanidad",

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -8,7 +8,7 @@
       "darkAriaLabel": "Unha lúa de ollos sospeitosos que parece que está a piques de foderse"
     },
     "home": {
-      "tituloPricipal": "Vacinación COVID-19 en",
+      "tituloPricipal": "Vacinación COVID-19 en España",
       "datosActualizados": "Datos actualizados",
       "fuente": "Fonte:",
       "ministerioDeSanidad": "Ministerio de Sanidade",


### PR DESCRIPTION
En catalán, la ñ no existe, por lo tanto usamos la NY.
Sin embargo, en el título se seguía usando la Ñ. He arreglado esto.

Problemas:
1. Falta la traducción en gallego y euskera.
2. ~~He quitado una línea de código que no entendía (pages/index.js L66). Podría causar problemas.~~