### PR TITLE
Continuación PR #134

### DIFF
--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -101,7 +101,7 @@ export default function Table ({ data, filter, setFilter, reportFound }) {
 
   return (
     <div className={styles.container}>
-      <table className={styles.table} {...getTableProps()} border='0' cellspacing='0' cellpadding='0'>
+      <table className={styles.table} {...getTableProps()} border='0' cellSpacing='0' cellPadding='0'>
         <thead>
           {headerGroups.map(headerGroup => (
             <tr {...headerGroup.getHeaderGroupProps()}>
@@ -136,7 +136,11 @@ export default function Table ({ data, filter, setFilter, reportFound }) {
                 {row.cells.map(cell => {
                   return (
                     <td {...cell.getCellProps()}>
-                      {cell.column.format(cell.value)}
+                      {
+                        cell.column.id === 'ccaa'
+                        ? translate.table.ccaa[cell.value]
+                        : cell.column.format(cell.value)
+                      }
                     </td>
                   )
                 })}

--- a/pages/index.js
+++ b/pages/index.js
@@ -67,7 +67,7 @@ export default function Home ({ contributors, data, info, reports, chartDatasets
       <div id='container' className={styles.container}>
         <main className={styles.main}>
           <h1 className={styles.title}>
-            {translate.home.tituloPrincipal} {filter === 'Totales' ? 'España' : filter}
+            {translate.home.tituloPrincipal} {filter === 'Totales' ? translate.home.pais : translate.table.ccaa[filter]}
           </h1>
           <small className={styles.description}>
             {translate.home.datosActualizados} <TimeAgo timestamp={info.lastModified} />.

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -1,90 +1,115 @@
 {
-    "colorSwitcher": {
-      "lightTitleLabel": "Utilitza el tema clar",
-      "lightAriaLabel": "Un sol que invertit sembla el dolent de Doom",
-      "standardTitleLabel": "Utilitza el tema depenent la configuració de sistema",
-      "standardAriaLabel": "Les teves preferències molones del teu sistema",
-      "darkTitleLabel": "Utilitza el tema fosc",
-      "darkAriaLabel": "Una lluna amb ulls sospitosos que sembla que està tramant alguna cosa fotuda"
-    },
-    "home": {
-      "tituloPrincipal": "Vacunació COVID-19 a",
-      "datosActualizados": "Dades actualitzades",
-      "fuente": "Font:",
-      "ministerioDeSanidad": "Ministeri de Sanitat",
-      "mostrarReporteFecha": "Mostrar dades a data",
-      "seleccionarFecha": "Seleccionar data",
-      "descargarDatosJSON": "Descarregar dades en format JSON",
-      "incrustarDatos": "Vull incrustar les dades de vacunació en una altra pàgina web",
-      "porComunidadesAutonomas": "Per comunitats autònomes",
-      "dosisEntregadas": "Dosis entregades",
-      "dosisAdministradas": "Dosis administrades",
-      "sobreEntregadas": "% sobre entregades",
-      "poblacionVacunada": "% població vacunada",
-      "pautaCompleta": "Pauta completa",
-      "poblacionTotalmenteVacunada": "% població totalment vacunada",
-      "evolucionDosisEntregadas": "Evolució de dosis lliurades",
-      "evolucionDosisAdministradas": "Evolució de dosis administrades",
-      "fuenteDatosEnlacesInteres": "Fonts de dades i enllaços d'interès",
-      "fuente1": "Estratègia de Vacunació COVID-19 a Espanya",
-      "fuente2": "Informació oficial sobre la vacunació contra el nou coronavirus",
-      "changelog": "changelog",
-      "changelog5": "Afegides gràfiques",
-      "changelog5.1": "i contribuïdors",
-      "changelog4": "Afegida la possibilitat d'incrustar les dades en una altra pàgina",
-      "changelog3": "Afegida la versió fosca a l'app",
-      "changelog2": "Afegida barra de progrés de vacunació en població",
-      "changelog1": "Afegides persones amb pauta completa",
-      "changelog0": "primera versió",
-      "enLosMedios": "En els mitjans",
-      "medio1": "Llancen un web amb dades de el Govern que permet veure com avança a Espanya la vacunació contra el coronavirus (20 Minuts)",
-      "medio2": "Web per revisar l'estat i progrés de la vacunació de l'COVID-19 a Espanya (Menéame)",
-      "medio3": "1.000 voluntaris per a una sola web: així evoluciona la vacunació a la teva comunitat (El Confidencial)",
-      "contribuidores": "Contribuïdors",
-      "alt": {
-        "vacunasDistribuidas": "Vacunes distribuïdes a Espanya",
-        "pfizerLogo": "Pfizer Logo",
-        "modernaLogo": "moderna Logo",
-        "astrazenecaLogo": "Astrazeneca Logo",
-        "vacunasAdministradas": "Vacunes administrades a Espanya",
-        "dosisCompletas": "Dosis completes subministrades",
-        "descargarDatos": "descarregar dades",
-        "incrustarDatos": "Incrusta dades en una pàgina web",
-        "graficaSubiendo": "gràfica pujant",
-        "emojiCiclista": "Emoji de ciclista",
-        "globoMundo": "Globus del món amb meridians",
-        "luna": "Lluna",
-        "globoTerricola": "Globus terrícola amb vista a Amèrica",
-        "jeringuilla": "xeringa",
-        "fuego": "foc"
-      }
-    },
-    "progress": {
-      "verPoblacionVacunada": "Població vacunada",
-      "verPoblacionConPauta": "Població amb pauta completa",
-      "estimacionPoblacionVacunada": "Estimació població vacunada",
-      "noDatos": "No disposem de dades per a aquesta data."
-    },
-    "terminos": {
-      "dosisDistribuidas": "Dosis distribuïdes",
-      "dosisAdministradas": "Dosis administrades",
-      "sobreDistribuidas": "% sobre distribuïdes",
-      "personasConPautaCompleta": "Persones amb pauta completa",
-      "sobreAdministradas": "% sobre administrades"
-    },
-    "share": {
-      "textParamUrl": "Segueix el progrés de la vacunació contra el COVID19 en aquesta web creada per @midudev!\n\n",
-      "titleAnchor": "Comparteix aquest enllaç a Twitter",
-      "textoButton": "Comparteix-lo!"
-    },
-    "footer": {
-      "desarrolladoPor": "Desenvolupat per",
-      "estadisticas": "Estadístiques",
-      "enviarSugerencia": "Enviar suggeriment"
-    },
-    "mapa": {
-        "sobreEntregadas": "sobre el total d'entregades",
-        "poblacionVacunada": "població vacunada",
-        "poblacionTotalmenteVacunada": "població totalment vacunada"
+  "table": {
+    "ccaa": {
+      "Andalucía": "Andalucía",
+      "Aragón": "Aragón",
+      "Asturias": "Asturias",
+      "Baleares": "Baleares",
+      "Canarias": "Canarias",
+      "Cantabria": "Cantabria",
+      "Castilla y Leon": "Castilla y Leon",
+      "Castilla La Mancha": "Castilla La Mancha",
+      "Cataluña": "Cataluña",
+      "C. Valenciana": "C. Valenciana",
+      "Extremadura": "Extremadura",
+      "Galicia": "Galicia",
+      "La Rioja": "La Rioja",
+      "Madrid": "Madrid",
+      "Murcia": "Murcia",
+      "Navarra": "Navarra",
+      "País Vasco": "País Vasco",
+      "Ceuta": "Ceuta",
+      "Melilla": "Melilla",
+      "Totales": "Totals"
     }
+  },
+  "colorSwitcher": {
+    "lightTitleLabel": "Utilitza el tema clar",
+    "lightAriaLabel": "Un sol que invertit sembla el dolent de Doom",
+    "standardTitleLabel": "Utilitza el tema depenent la configuració de sistema",
+    "standardAriaLabel": "Les teves preferències molones del teu sistema",
+    "darkTitleLabel": "Utilitza el tema fosc",
+    "darkAriaLabel": "Una lluna amb ulls sospitosos que sembla que està tramant alguna cosa fotuda"
+  },
+  "home": {
+    "tituloPrincipal": "Vacunació COVID-19 a",
+    "pais": "Espanya",
+    "datosActualizados": "Dades actualitzades",
+    "fuente": "Font:",
+    "ministerioDeSanidad": "Ministeri de Sanitat",
+    "mostrarReporteFecha": "Mostrar dades a data",
+    "seleccionarFecha": "Seleccionar data",
+    "descargarDatosJSON": "Descarregar dades en format JSON",
+    "incrustarDatos": "Vull incrustar les dades de vacunació en una altra pàgina web",
+    "porComunidadesAutonomas": "Per comunitats autònomes",
+    "dosisEntregadas": "Dosis entregades",
+    "dosisAdministradas": "Dosis administrades",
+    "sobreEntregadas": "% sobre entregades",
+    "poblacionVacunada": "% població vacunada",
+    "pautaCompleta": "Pauta completa",
+    "poblacionTotalmenteVacunada": "% població totalment vacunada",
+    "evolucionDosisEntregadas": "Evolució de dosis lliurades",
+    "evolucionDosisAdministradas": "Evolució de dosis administrades",
+    "fuenteDatosEnlacesInteres": "Fonts de dades i enllaços d'interès",
+    "fuente1": "Estratègia de Vacunació COVID-19 a Espanya",
+    "fuente2": "Informació oficial sobre la vacunació contra el nou coronavirus",
+    "changelog": "changelog",
+    "changelog5": "Afegides gràfiques",
+    "changelog5.1": "i contribuïdors",
+    "changelog4": "Afegida la possibilitat d'incrustar les dades en una altra pàgina",
+    "changelog3": "Afegida la versió fosca a l'app",
+    "changelog2": "Afegida barra de progrés de vacunació en població",
+    "changelog1": "Afegides persones amb pauta completa",
+    "changelog0": "primera versió",
+    "enLosMedios": "En els mitjans",
+    "medio1": "Llancen un web amb dades de el Govern que permet veure com avança a Espanya la vacunació contra el coronavirus (20 Minuts)",
+    "medio2": "Web per revisar l'estat i progrés de la vacunació de l'COVID-19 a Espanya (Menéame)",
+    "medio3": "1.000 voluntaris per a una sola web: així evoluciona la vacunació a la teva comunitat (El Confidencial)",
+    "contribuidores": "Contribuïdors",
+    "alt": {
+      "vacunasDistribuidas": "Vacunes distribuïdes a Espanya",
+      "pfizerLogo": "Pfizer Logo",
+      "modernaLogo": "moderna Logo",
+      "astrazenecaLogo": "Astrazeneca Logo",
+      "vacunasAdministradas": "Vacunes administrades a Espanya",
+      "dosisCompletas": "Dosis completes subministrades",
+      "descargarDatos": "descarregar dades",
+      "incrustarDatos": "Incrusta dades en una pàgina web",
+      "graficaSubiendo": "gràfica pujant",
+      "emojiCiclista": "Emoji de ciclista",
+      "globoMundo": "Globus del món amb meridians",
+      "luna": "Lluna",
+      "globoTerricola": "Globus terrícola amb vista a Amèrica",
+      "jeringuilla": "xeringa",
+      "fuego": "foc"
+    }
+  },
+  "progress": {
+    "verPoblacionVacunada": "Població vacunada",
+    "verPoblacionConPauta": "Població amb pauta completa",
+    "estimacionPoblacionVacunada": "Estimació població vacunada",
+    "noDatos": "No disposem de dades per a aquesta data."
+  },
+  "terminos": {
+    "dosisDistribuidas": "Dosis distribuïdes",
+    "dosisAdministradas": "Dosis administrades",
+    "sobreDistribuidas": "% sobre distribuïdes",
+    "personasConPautaCompleta": "Persones amb pauta completa",
+    "sobreAdministradas": "% sobre administrades"
+  },
+  "share": {
+    "textParamUrl": "Segueix el progrés de la vacunació contra el COVID19 en aquesta web creada per @midudev!\n\n",
+    "titleAnchor": "Comparteix aquest enllaç a Twitter",
+    "textoButton": "Comparteix-lo!"
+  },
+  "footer": {
+    "desarrolladoPor": "Desenvolupat per",
+    "estadisticas": "Estadístiques",
+    "enviarSugerencia": "Enviar suggeriment"
+  },
+  "mapa": {
+    "sobreEntregadas": "sobre el total d'entregades",
+    "poblacionVacunada": "població vacunada",
+    "poblacionTotalmenteVacunada": "població totalment vacunada"
+  }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1,91 +1,115 @@
 {
-    "colorSwitcher": {
-        "lightTitleLabel": "Usa el tema claro",
-        "lightAriaLabel": "Un sol que invertido parece el malo de Doom",
-        "standardTitleLabel": "Usa el tema dependiendo tu configuración de sistema",
-        "standardAriaLabel": "Tus preferencias molonas de tu sistema",
-        "darkTitleLabel": "Usa el tema oscuro",
-        "darkAriaLabel": "Una luna con ojos sospechosos que parece que está tramando algo jodido"
-
-    },
-    "home": {
-        "tituloPrincipal": "Vacunación COVID-19 en",
-        "datosActualizados": "Datos actualizados",
-        "fuente": "Fuente:",
-        "ministerioDeSanidad": "Ministerio de Sanidad",
-        "mostrarReporteFecha": "Mostrar reporte a la fecha",
-        "seleccionarFecha": "Seleccionar fecha",
-        "descargarDatosJSON": "Descargar datos en formato JSON",
-        "incrustarDatos": "Quiero incrustar los datos de vacunación en otra página web",
-        "porComunidadesAutonomas": "Por comunidades autónomas",
-        "dosisEntregadas": "Dosis entregadas",
-        "dosisAdministradas": "Dosis administradas",
-        "sobreEntregadas": "% sobre entregadas",
-        "poblacionVacunada": "% población vacunada",
-        "pautaCompleta": "Pauta completa",
-        "poblacionTotalmenteVacunada": "% población totalmente vacunada",
-        "evolucionDosisEntregadas": "Evolución de dosis entregadas",
-        "evolucionDosisAdministradas": "Evolución de dosis administradas",
-        "fuenteDatosEnlacesInteres": "Fuentes de datos y enlaces de interés",
-        "fuente1": "Estrategia de Vacunación COVID-19 en España",
-        "fuente2": "Información oficial sobre la vacunación contra el nuevo coronavirus",
-        "changelog": "Changelog",
-        "changelog5": "Añadidas gráficas",
-        "changelog5.1": "y contribuidores",
-        "changelog4": "Añadida la posibilidad de incrustar los datos en otra página",
-        "changelog3": "Añadido modo oscuro a la app",
-        "changelog2": "Añadida barra de progreso de vacunación en población",
-        "changelog1": "Añadidas personas con pauta completa",
-        "changelog0": "Primera versión",
-        "enLosMedios": "En los medios",
-        "medio1": "Lanzan una web con datos del Gobierno que permite ver cómo avanza en España la vacunación contra el coronavirus (20 Minutos)",
-        "medio2": "Web para revisar el estado y progreso de la vacunación del COVID-19 en España (Menéame)",
-        "medio3": "1.000 voluntarios para una sola web: así evoluciona la vacunación en tu comunidad (El Confidencial)",
-        "contribuidores": "Contribuidores",
-        "alt": {
-            "vacunasDistribuidas": "Vacunas distribuidas en España",
-            "pfizerLogo": "Pfizer Logo",
-            "modernaLogo": "Moderna Logo",
-            "astrazenecaLogo": "Astrazeneca Logo",
-            "vacunasAdministradas": "Vacunas administradas en España",
-            "dosisCompletas": "Dosis completas subministradas",
-            "descargarDatos": "Descargar datos",
-            "incrustarDatos": "Incrustar datos en una página web",
-            "graficaSubiendo": "Gráfica subiendo",
-            "emojiCiclista": "Emoji de ciclista",
-            "globoMundo": "Globo del mundo con meridianos",
-            "luna": "Luna",
-            "globoTerricola": "Globo terrícola con vistas a América",
-            "jeringuilla": "Jeringuilla",
-            "fuego": "Fuego"
-        }
-    },
-    "progress": {
-        "verPoblacionVacunada": "Población vacunada",
-        "verPoblacionConPauta": "Población con pauta completa",
-        "estimacionPoblacionVacunada": "Estimación población vacunada",
-        "noDatos": "No disponemos de datos para esa fecha."
-    },
-    "terminos": {
-        "dosisDistribuidas": "Dosis distribuidas",
-        "dosisAdministradas": "Dosis administradas",
-        "sobreDistribuidas": "% sobre distribuidas",
-        "personasConPautaCompleta": "Personas con pauta completa",
-        "sobreAdministradas": "% sobre administradas"
-    },
-    "share": {
-        "textParamUrl": "¡Sigue el progreso de la vacunación contra el COVID19 en esta web creada por @midudev!\n\n",
-        "titleAnchor": "Comparte este enlace en Twitter",
-        "textoButton": "¡Compártelo!"
-    },
-    "footer": {
-        "desarrolladoPor": "Desarrollado por",
-        "estadisticas": "Estadísticas",
-        "enviarSugerencia": "Enviar sugerencia"
-    },
-    "mapa": {
-        "sobreEntregadas": "sobre el total de entregadas",
-        "poblacionVacunada": "población vacunada",
-        "poblacionTotalmenteVacunada": "población totalmente vacunada"
+  "table": {
+    "ccaa": {
+      "Andalucía": "Andalucía",
+      "Aragón": "Aragón",
+      "Asturias": "Asturias",
+      "Baleares": "Baleares",
+      "Canarias": "Canarias",
+      "Cantabria": "Cantabria",
+      "Castilla y Leon": "Castilla y Leon",
+      "Castilla La Mancha": "Castilla La Mancha",
+      "Cataluña": "Cataluña",
+      "C. Valenciana": "C. Valenciana",
+      "Extremadura": "Extremadura",
+      "Galicia": "Galicia",
+      "La Rioja": "La Rioja",
+      "Madrid": "Madrid",
+      "Murcia": "Murcia",
+      "Navarra": "Navarra",
+      "País Vasco": "País Vasco",
+      "Ceuta": "Ceuta",
+      "Melilla": "Melilla",
+      "Totales": "Totales"
     }
+  },
+  "colorSwitcher": {
+    "lightTitleLabel": "Usa el tema claro",
+    "lightAriaLabel": "Un sol que invertido parece el malo de Doom",
+    "standardTitleLabel": "Usa el tema dependiendo tu configuración de sistema",
+    "standardAriaLabel": "Tus preferencias molonas de tu sistema",
+    "darkTitleLabel": "Usa el tema oscuro",
+    "darkAriaLabel": "Una luna con ojos sospechosos que parece que está tramando algo jodido"
+  },
+  "home": {
+    "tituloPrincipal": "Vacunación COVID-19 en",
+    "pais": "España",
+    "datosActualizados": "Datos actualizados",
+    "fuente": "Fuente:",
+    "ministerioDeSanidad": "Ministerio de Sanidad",
+    "mostrarReporteFecha": "Mostrar reporte a la fecha",
+    "seleccionarFecha": "Seleccionar fecha",
+    "descargarDatosJSON": "Descargar datos en formato JSON",
+    "incrustarDatos": "Quiero incrustar los datos de vacunación en otra página web",
+    "porComunidadesAutonomas": "Por comunidades autónomas",
+    "dosisEntregadas": "Dosis entregadas",
+    "dosisAdministradas": "Dosis administradas",
+    "sobreEntregadas": "% sobre entregadas",
+    "poblacionVacunada": "% población vacunada",
+    "pautaCompleta": "Pauta completa",
+    "poblacionTotalmenteVacunada": "% población totalmente vacunada",
+    "evolucionDosisEntregadas": "Evolución de dosis entregadas",
+    "evolucionDosisAdministradas": "Evolución de dosis administradas",
+    "fuenteDatosEnlacesInteres": "Fuentes de datos y enlaces de interés",
+    "fuente1": "Estrategia de Vacunación COVID-19 en España",
+    "fuente2": "Información oficial sobre la vacunación contra el nuevo coronavirus",
+    "changelog": "Changelog",
+    "changelog5": "Añadidas gráficas",
+    "changelog5.1": "y contribuidores",
+    "changelog4": "Añadida la posibilidad de incrustar los datos en otra página",
+    "changelog3": "Añadido modo oscuro a la app",
+    "changelog2": "Añadida barra de progreso de vacunación en población",
+    "changelog1": "Añadidas personas con pauta completa",
+    "changelog0": "Primera versión",
+    "enLosMedios": "En los medios",
+    "medio1": "Lanzan una web con datos del Gobierno que permite ver cómo avanza en España la vacunación contra el coronavirus (20 Minutos)",
+    "medio2": "Web para revisar el estado y progreso de la vacunación del COVID-19 en España (Menéame)",
+    "medio3": "1.000 voluntarios para una sola web: así evoluciona la vacunación en tu comunidad (El Confidencial)",
+    "contribuidores": "Contribuidores",
+    "alt": {
+      "vacunasDistribuidas": "Vacunas distribuidas en España",
+      "pfizerLogo": "Pfizer Logo",
+      "modernaLogo": "Moderna Logo",
+      "astrazenecaLogo": "Astrazeneca Logo",
+      "vacunasAdministradas": "Vacunas administradas en España",
+      "dosisCompletas": "Dosis completas subministradas",
+      "descargarDatos": "Descargar datos",
+      "incrustarDatos": "Incrustar datos en una página web",
+      "graficaSubiendo": "Gráfica subiendo",
+      "emojiCiclista": "Emoji de ciclista",
+      "globoMundo": "Globo del mundo con meridianos",
+      "luna": "Luna",
+      "globoTerricola": "Globo terrícola con vistas a América",
+      "jeringuilla": "Jeringuilla",
+      "fuego": "Fuego"
+    }
+  },
+  "progress": {
+    "verPoblacionVacunada": "Población vacunada",
+    "verPoblacionConPauta": "Población con pauta completa",
+    "estimacionPoblacionVacunada": "Estimación población vacunada",
+    "noDatos": "No disponemos de datos para esa fecha."
+  },
+  "terminos": {
+    "dosisDistribuidas": "Dosis distribuidas",
+    "dosisAdministradas": "Dosis administradas",
+    "sobreDistribuidas": "% sobre distribuidas",
+    "personasConPautaCompleta": "Personas con pauta completa",
+    "sobreAdministradas": "% sobre administradas"
+  },
+  "share": {
+    "textParamUrl": "¡Sigue el progreso de la vacunación contra el COVID19 en esta web creada por @midudev!\n\n",
+    "titleAnchor": "Comparte este enlace en Twitter",
+    "textoButton": "¡Compártelo!"
+  },
+  "footer": {
+    "desarrolladoPor": "Desarrollado por",
+    "estadisticas": "Estadísticas",
+    "enviarSugerencia": "Enviar sugerencia"
+  },
+  "mapa": {
+    "sobreEntregadas": "sobre el total de entregadas",
+    "poblacionVacunada": "población vacunada",
+    "poblacionTotalmenteVacunada": "población totalmente vacunada"
+  }
 }

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -1,90 +1,115 @@
 {
-    "colorSwitcher": {
-      "lightTitleLabel": "Erabili gai argia",
-      "lightAriaLabel": "Alderantziz jarritako eguzkia Doom-eko gaiztoaren itxura du",
-      "standardTitleLabel": "Erabili gaia zure sistemaren konfigurazioaren arabera",
-      "standardAriaLabel": "Zure sistemaren hobespen bikainak",
-      "darkTitleLabel": "Erabili gai iluna",
-      "darkAriaLabel": "Begi susmagarriak dituen ilargia, izorratuta dagoen zerbait dela dirudi"
-    },
-    "home": {
-      "tituloPrincipal": "COVID-19 txertoa",
-      "datosActualizados": "Eguneratutako datuak",
-      "fuente": "Iturria:",
-      "ministerioDeSanidad": "Osasun Ministerioa",
-      "mostrarReporteFecha": "Erakutsi txostena orain arte",
-      "seleccionarFecha": "Hautatu data",
-      "descargarDatosJSON": "Deskargatu datuak JSON formatuan",
-      "incrustarDatos": "Txertaketa datuak beste web orri batean txertatu nahi ditut",
-      "porComunidadesAutonomas": "Autonomia erkidegoen arabera",
-      "dosisEntregadas": "Entregatutako dosiak",
-      "dosisAdministradas": "Emandako dosiak",
-      "sobreEntregadas": "% buruz entregatutako",
-      "poblacionVacunada": "% txertatutako populazioa",
-      "pautaCompleta": "Jarraibide osoa",
-      "poblacionTotalmenteVacunada": "% guztiz txertatutako populazioa",
-      "evolucionDosisEntregadas": "Emandako dosien bilakaera",
-      "evolucionDosisAdministradas": "Administratutako dosien bilakaera",
-      "fuenteDatosEnlacesInteres": "Datu iturriak eta esteka interesgarriak",
-      "fuente1": "COVID-19 Txertaketa Estrategia Espainian",
-      "fuente2": "Koronabirus berriaren aurkako txertoari buruzko informazio ofiziala",
-      "changelog": "Aldaketa-erregistroa",
-      "changelog5": "Gehitutako grafikoak",
-      "changelog5.1": "eta laguntzaileak",
-      "changelog4": "Datuak beste orri batean txertatzeko aukera gehitu da",
-      "changelog3": "Modu iluna gehitu da aplikazioan",
-      "changelog2": "Gehitu da biztanleriaren txertoa aurrera egiteko barra",
-      "changelog1": "Jarraibide osoak dituzten pertsonak gehitu dira",
-      "changelog0": "Lehen bertsioa",
-      "enLosMedios": "Komunikabideetan",
-      "medio1": "Webgune bat estreinatu dute gobernuaren datuekin, Espainian coronavirusaren aurkako txertoa nola garatzen ari den ikusteko aukera ematen diguna (20 minutu)",
-      "medio2": "COVID-19 txertaketaren egoera eta aurrerapenak aztertzeko webgunea Espainian (Menéame)",
-      "medio3": "1.000 boluntario webgune bakarrerako: horrela garatzen da txertaketa zure komunitatean (El Confidencial)",
-      "contribuidores": "Laguntzaileak",
-      "alt": {
-        "vacunasDistribuidas": "Espainian banatutako txertoak",
-        "pfizerLogo": "Pfizer logotipoa",
-        "modernaLogo": "Logotipo modernoa",
-        "astrazenecaLogo": "Astrazeneca logotipoa",
-        "vacunasAdministradas": "Espainian ematen diren txertoak",
-        "dosisCompletas": "Administratutako dosi osoak",
-        "descargarDatos": "Datuak deskargatu",
-        "incrustarDatos": "Datuak txertatu web orri batean",
-        "graficaSubiendo": "Grafikoa gorantz doa",
-        "emojiCiclista": "Biker emoji",
-        "globoMundo": "Munduko globoa meridianoekin",
-        "luna": "Ilargia",
-        "globoTerricola": "Lurreko globoa Amerikara begira",
-        "jeringuilla": "Xiringa",
-        "fuego": "Sute"
-      }
-    },
-    "progress": {
-      "verPoblacionVacunada": "Txertatutako populazioa",
-      "verPoblacionConPauta": "Populazioa jarraibide osoekin",
-      "estimacionPoblacionVacunada": "Txertatutako biztanleriaren estimazioa",
-      "noDatos": "Ez dugu data horretarako daturik."
-    },
-    "terminos": {
-      "dosisDistribuidas": "Banatutako dosiak",
-      "dosisAdministradas": "Administratutako dosia",
-      "sobreDistribuidas": "% banatutakoaren gainekoa",
-      "personasConPautaCompleta": "Jarraibide osoa duten pertsonak",
-      "sobreAdministradas": "% baino gehiago kudeatzen da"
-    },
-    "share": {
-      "textParamUrl": "Jarrai ezazu COVID19ren aurkako txertoaren aurrerapena @midudev-ek sortutako webgune honetan!\n\n",
-      "titleAnchor": "Partekatu esteka hau Twitterren",
-      "textoButton": "Parteka ezazu!"
-    },
-    "footer": {
-      "desarrolladoPor": "Garatu du",
-      "estadisticas": "Estatistikak",
-      "enviarSugerencia": "Bidali iradokizuna"
-    },
-    "mapa": {
-        "sobreEntregadas": "entregatutako guztiaren gainean",
-        "poblacionVacunada": "txertatutako populazioa",
-        "poblacionTotalmenteVacunada": "guztiz txertatutako populazioa"
+  "table": {
+    "ccaa": {
+      "Andalucía": "Andalucía",
+      "Aragón": "Aragón",
+      "Asturias": "Asturias",
+      "Baleares": "Baleares",
+      "Canarias": "Canarias",
+      "Cantabria": "Cantabria",
+      "Castilla y Leon": "Castilla y Leon",
+      "Castilla La Mancha": "Castilla La Mancha",
+      "Cataluña": "Cataluña",
+      "C. Valenciana": "C. Valenciana",
+      "Extremadura": "Extremadura",
+      "Galicia": "Galicia",
+      "La Rioja": "La Rioja",
+      "Madrid": "Madrid",
+      "Murcia": "Murcia",
+      "Navarra": "Navarra",
+      "País Vasco": "País Vasco",
+      "Ceuta": "Ceuta",
+      "Melilla": "Melilla",
+      "Totales": "Guztira"
     }
+  },
+  "colorSwitcher": {
+    "lightTitleLabel": "Erabili gai argia",
+    "lightAriaLabel": "Alderantziz jarritako eguzkia Doom-eko gaiztoaren itxura du",
+    "standardTitleLabel": "Erabili gaia zure sistemaren konfigurazioaren arabera",
+    "standardAriaLabel": "Zure sistemaren hobespen bikainak",
+    "darkTitleLabel": "Erabili gai iluna",
+    "darkAriaLabel": "Begi susmagarriak dituen ilargia, izorratuta dagoen zerbait dela dirudi"
+  },
+  "home": {
+    "tituloPrincipal": "COVID-19 txertoa",
+    "pais": "Espainia",
+    "datosActualizados": "Eguneratutako datuak",
+    "fuente": "Iturria:",
+    "ministerioDeSanidad": "Osasun Ministerioa",
+    "mostrarReporteFecha": "Erakutsi txostena orain arte",
+    "seleccionarFecha": "Hautatu data",
+    "descargarDatosJSON": "Deskargatu datuak JSON formatuan",
+    "incrustarDatos": "Txertaketa datuak beste web orri batean txertatu nahi ditut",
+    "porComunidadesAutonomas": "Autonomia erkidegoen arabera",
+    "dosisEntregadas": "Entregatutako dosiak",
+    "dosisAdministradas": "Emandako dosiak",
+    "sobreEntregadas": "% buruz entregatutako",
+    "poblacionVacunada": "% txertatutako populazioa",
+    "pautaCompleta": "Jarraibide osoa",
+    "poblacionTotalmenteVacunada": "% guztiz txertatutako populazioa",
+    "evolucionDosisEntregadas": "Emandako dosien bilakaera",
+    "evolucionDosisAdministradas": "Administratutako dosien bilakaera",
+    "fuenteDatosEnlacesInteres": "Datu iturriak eta esteka interesgarriak",
+    "fuente1": "COVID-19 Txertaketa Estrategia Espainian",
+    "fuente2": "Koronabirus berriaren aurkako txertoari buruzko informazio ofiziala",
+    "changelog": "Aldaketa-erregistroa",
+    "changelog5": "Gehitutako grafikoak",
+    "changelog5.1": "eta laguntzaileak",
+    "changelog4": "Datuak beste orri batean txertatzeko aukera gehitu da",
+    "changelog3": "Modu iluna gehitu da aplikazioan",
+    "changelog2": "Gehitu da biztanleriaren txertoa aurrera egiteko barra",
+    "changelog1": "Jarraibide osoak dituzten pertsonak gehitu dira",
+    "changelog0": "Lehen bertsioa",
+    "enLosMedios": "Komunikabideetan",
+    "medio1": "Webgune bat estreinatu dute gobernuaren datuekin, Espainian coronavirusaren aurkako txertoa nola garatzen ari den ikusteko aukera ematen diguna (20 minutu)",
+    "medio2": "COVID-19 txertaketaren egoera eta aurrerapenak aztertzeko webgunea Espainian (Menéame)",
+    "medio3": "1.000 boluntario webgune bakarrerako: horrela garatzen da txertaketa zure komunitatean (El Confidencial)",
+    "contribuidores": "Laguntzaileak",
+    "alt": {
+      "vacunasDistribuidas": "Espainian banatutako txertoak",
+      "pfizerLogo": "Pfizer logotipoa",
+      "modernaLogo": "Logotipo modernoa",
+      "astrazenecaLogo": "Astrazeneca logotipoa",
+      "vacunasAdministradas": "Espainian ematen diren txertoak",
+      "dosisCompletas": "Administratutako dosi osoak",
+      "descargarDatos": "Datuak deskargatu",
+      "incrustarDatos": "Datuak txertatu web orri batean",
+      "graficaSubiendo": "Grafikoa gorantz doa",
+      "emojiCiclista": "Biker emoji",
+      "globoMundo": "Munduko globoa meridianoekin",
+      "luna": "Ilargia",
+      "globoTerricola": "Lurreko globoa Amerikara begira",
+      "jeringuilla": "Xiringa",
+      "fuego": "Sute"
+    }
+  },
+  "progress": {
+    "verPoblacionVacunada": "Txertatutako populazioa",
+    "verPoblacionConPauta": "Populazioa jarraibide osoekin",
+    "estimacionPoblacionVacunada": "Txertatutako biztanleriaren estimazioa",
+    "noDatos": "Ez dugu data horretarako daturik."
+  },
+  "terminos": {
+    "dosisDistribuidas": "Banatutako dosiak",
+    "dosisAdministradas": "Administratutako dosia",
+    "sobreDistribuidas": "% banatutakoaren gainekoa",
+    "personasConPautaCompleta": "Jarraibide osoa duten pertsonak",
+    "sobreAdministradas": "% baino gehiago kudeatzen da"
+  },
+  "share": {
+    "textParamUrl": "Jarrai ezazu COVID19ren aurkako txertoaren aurrerapena @midudev-ek sortutako webgune honetan!\n\n",
+    "titleAnchor": "Partekatu esteka hau Twitterren",
+    "textoButton": "Parteka ezazu!"
+  },
+  "footer": {
+    "desarrolladoPor": "Garatu du",
+    "estadisticas": "Estatistikak",
+    "enviarSugerencia": "Bidali iradokizuna"
+  },
+  "mapa": {
+    "sobreEntregadas": "entregatutako guztiaren gainean",
+    "poblacionVacunada": "txertatutako populazioa",
+    "poblacionTotalmenteVacunada": "guztiz txertatutako populazioa"
   }
+}

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -1,90 +1,115 @@
 {
-    "colorSwitcher": {
-      "lightTitleLabel": "Usa o tema claro",
-      "lightAriaLabel": "Un sol invertido semella o malo de Doom",
-      "standardTitleLabel": "Use o tema dependendo da configuración do seu sistema",
-      "standardAriaLabel": "As túas preferencias de sistema interesantes",
-      "darkTitleLabel": "Usa o tema escuro",
-      "darkAriaLabel": "Unha lúa de ollos sospeitosos que parece que está a piques de foderse"
-    },
-    "home": {
-      "tituloPrincipal": "Vacinación COVID-19 en",
-      "datosActualizados": "Datos actualizados",
-      "fuente": "Fonte:",
-      "ministerioDeSanidad": "Ministerio de Sanidade",
-      "mostrarReporteFecha": "Amosar informe ata a data",
-      "seleccionarFecha": "Seleccionar data",
-      "descargarDatosJSON": "Descarga os datos en formato JSON",
-      "incrustarDatos": "Quero inserir os datos de vacinación noutra páxina web",
-      "porComunidadesAutonomas": "Por comunidades autónomas",
-      "dosisEntregadas": "Doses entregadas",
-      "dosisAdministradas": "Doses administradas",
-      "sobreEntregadas": "% dos entregadas",
-      "poblacionVacunada": "% poboación vacinada",
-      "pautaCompleta": "Pauta completa",
-      "poblacionTotalmenteVacunada": "% poboación totalmente vacinada",
-      "evolucionDosisEntregadas": "Evolución das doses entregadas",
-      "evolucionDosisAdministradas": "Evolución das doses administradas",
-      "fuenteDatosEnlacesInteres": "Fontes de datos e ligazóns de interese",
-      "fuente1": "Estratexia de vacinación COVID-19 en España",
-      "fuente2": "Información oficial sobre a vacinación contra o novo coronavirus",
-      "changelog": "Rexistro de cambios",
-      "changelog5": "Engadíronse gráficos",
-      "changelog5.1": "e colaboradores",
-      "changelog4": "Engadiuse a posibilidade de incrustar os datos noutra páxina",
-      "changelog3": "Engadiuse o modo escuro á aplicación",
-      "changelog2": "Engadiuse a barra de progreso da vacinación poboacional",
-      "changelog1": "Engadíronse persoas con directrices completas",
-      "changelog0": "Primeira versión",
-      "enLosMedios": "Nos medios",
-      "medio1": "Lanzan un sitio web con datos gobernamentais que nos permite ver como avanza a vacinación contra o coronavirus en España (20 minutos)",
-      "medio2": "Web para revisar o estado e o progreso da vacinación contra o COVID-19 en España (Menéame)",
-      "medio3": "1.000 voluntarios para unha soa web: así evoluciona a vacinación na túa comunidade (El Confidencial)",
-      "contribuidores": "Colaboradores",
-      "alt": {
-        "vacunasDistribuidas": "Vacinas distribuídas en España",
-        "pfizerLogo": "Logotipo de Pfizer",
-        "modernaLogo": "Logotipo moderno",
-        "astrazenecaLogo": "Logotipo de Astrazeneca",
-        "vacunasAdministradas": "Vacinas administradas en España",
-        "dosisCompletas": "Administrar doses completas",
-        "descargarDatos": "Descargar datos",
-        "incrustarDatos": "Inserir datos nunha páxina web",
-        "graficaSubiendo": "Gráfico subindo",
-        "emojiCiclista": "Emoji biker",
-        "globoMundo": "Globo mundial con meridianos",
-        "luna": "Lúa",
-        "globoTerricola": "Globo terrestre con vistas a América",
-        "jeringuilla": "Xiringa",
-        "fuego": "Lume"
-      }
-    },
-    "progress": {
-      "verPoblacionVacunada": "Poboación vacinada",
-      "verPoblacionConPauta": "Poboación con directrices completas",
-      "estimacionPoblacionVacunada": "Estimación da poboación vacinada",
-      "noDatos": "Non dispoñemos de datos para esa data."
-    },
-    "terminos": {
-      "dosisDistribuidas": "Doses distribuídas",
-      "dosisAdministradas": "Dose administrada",
-      "sobreDistribuidas": "% sobre distribuído",
-      "personasConPautaCompleta": "Persoas con directrices completas",
-      "sobreAdministradas": "% sobre xestionado"
-    },
-    "share": {
-      "textParamUrl": "Siga o progreso da vacinación contra COVID19 neste sitio web creado por @midudev.\n\n",
-      "titleAnchor": "Comparte esta ligazón en Twitter",
-      "textoButton": "Compárteo!"
-    },
-    "footer": {
-      "desarrolladoPor": "Desenvolvido por",
-      "estadisticas": "Estatísticas",
-      "enviarSugerencia": "Enviar suxestión"
-    },
-    "mapa": {
-        "sobreEntregadas": "sobre o total entregado",
-        "poblacionVacunada": "poboación vacinada",
-        "poblacionTotalmenteVacunada": "poboación totalmente vacinada"
+  "table": {
+    "ccaa": {
+      "Andalucía": "Andalucía",
+      "Aragón": "Aragón",
+      "Asturias": "Asturias",
+      "Baleares": "Baleares",
+      "Canarias": "Canarias",
+      "Cantabria": "Cantabria",
+      "Castilla y Leon": "Castilla y Leon",
+      "Castilla La Mancha": "Castilla La Mancha",
+      "Cataluña": "Cataluña",
+      "C. Valenciana": "C. Valenciana",
+      "Extremadura": "Extremadura",
+      "Galicia": "Galicia",
+      "La Rioja": "La Rioja",
+      "Madrid": "Madrid",
+      "Murcia": "Murcia",
+      "Navarra": "Navarra",
+      "País Vasco": "País Vasco",
+      "Ceuta": "Ceuta",
+      "Melilla": "Melilla",
+      "Totales": "Totais"
     }
+  },
+  "colorSwitcher": {
+    "lightTitleLabel": "Usa o tema claro",
+    "lightAriaLabel": "Un sol invertido semella o malo de Doom",
+    "standardTitleLabel": "Use o tema dependendo da configuración do seu sistema",
+    "standardAriaLabel": "As túas preferencias de sistema interesantes",
+    "darkTitleLabel": "Usa o tema escuro",
+    "darkAriaLabel": "Unha lúa de ollos sospeitosos que parece que está a piques de foderse"
+  },
+  "home": {
+    "tituloPrincipal": "Vacinación COVID-19 en",
+    "pais": "España",
+    "datosActualizados": "Datos actualizados",
+    "fuente": "Fonte:",
+    "ministerioDeSanidad": "Ministerio de Sanidade",
+    "mostrarReporteFecha": "Amosar informe ata a data",
+    "seleccionarFecha": "Seleccionar data",
+    "descargarDatosJSON": "Descarga os datos en formato JSON",
+    "incrustarDatos": "Quero inserir os datos de vacinación noutra páxina web",
+    "porComunidadesAutonomas": "Por comunidades autónomas",
+    "dosisEntregadas": "Doses entregadas",
+    "dosisAdministradas": "Doses administradas",
+    "sobreEntregadas": "% dos entregadas",
+    "poblacionVacunada": "% poboación vacinada",
+    "pautaCompleta": "Pauta completa",
+    "poblacionTotalmenteVacunada": "% poboación totalmente vacinada",
+    "evolucionDosisEntregadas": "Evolución das doses entregadas",
+    "evolucionDosisAdministradas": "Evolución das doses administradas",
+    "fuenteDatosEnlacesInteres": "Fontes de datos e ligazóns de interese",
+    "fuente1": "Estratexia de vacinación COVID-19 en España",
+    "fuente2": "Información oficial sobre a vacinación contra o novo coronavirus",
+    "changelog": "Rexistro de cambios",
+    "changelog5": "Engadíronse gráficos",
+    "changelog5.1": "e colaboradores",
+    "changelog4": "Engadiuse a posibilidade de incrustar os datos noutra páxina",
+    "changelog3": "Engadiuse o modo escuro á aplicación",
+    "changelog2": "Engadiuse a barra de progreso da vacinación poboacional",
+    "changelog1": "Engadíronse persoas con directrices completas",
+    "changelog0": "Primeira versión",
+    "enLosMedios": "Nos medios",
+    "medio1": "Lanzan un sitio web con datos gobernamentais que nos permite ver como avanza a vacinación contra o coronavirus en España (20 minutos)",
+    "medio2": "Web para revisar o estado e o progreso da vacinación contra o COVID-19 en España (Menéame)",
+    "medio3": "1.000 voluntarios para unha soa web: así evoluciona a vacinación na túa comunidade (El Confidencial)",
+    "contribuidores": "Colaboradores",
+    "alt": {
+      "vacunasDistribuidas": "Vacinas distribuídas en España",
+      "pfizerLogo": "Logotipo de Pfizer",
+      "modernaLogo": "Logotipo moderno",
+      "astrazenecaLogo": "Logotipo de Astrazeneca",
+      "vacunasAdministradas": "Vacinas administradas en España",
+      "dosisCompletas": "Administrar doses completas",
+      "descargarDatos": "Descargar datos",
+      "incrustarDatos": "Inserir datos nunha páxina web",
+      "graficaSubiendo": "Gráfico subindo",
+      "emojiCiclista": "Emoji biker",
+      "globoMundo": "Globo mundial con meridianos",
+      "luna": "Lúa",
+      "globoTerricola": "Globo terrestre con vistas a América",
+      "jeringuilla": "Xiringa",
+      "fuego": "Lume"
+    }
+  },
+  "progress": {
+    "verPoblacionVacunada": "Poboación vacinada",
+    "verPoblacionConPauta": "Poboación con directrices completas",
+    "estimacionPoblacionVacunada": "Estimación da poboación vacinada",
+    "noDatos": "Non dispoñemos de datos para esa data."
+  },
+  "terminos": {
+    "dosisDistribuidas": "Doses distribuídas",
+    "dosisAdministradas": "Dose administrada",
+    "sobreDistribuidas": "% sobre distribuído",
+    "personasConPautaCompleta": "Persoas con directrices completas",
+    "sobreAdministradas": "% sobre xestionado"
+  },
+  "share": {
+    "textParamUrl": "Siga o progreso da vacinación contra COVID19 neste sitio web creado por @midudev.\n\n",
+    "titleAnchor": "Comparte esta ligazón en Twitter",
+    "textoButton": "Compárteo!"
+  },
+  "footer": {
+    "desarrolladoPor": "Desenvolvido por",
+    "estadisticas": "Estatísticas",
+    "enviarSugerencia": "Enviar suxestión"
+  },
+  "mapa": {
+    "sobreEntregadas": "sobre o total entregado",
+    "poblacionVacunada": "poboación vacinada",
+    "poblacionTotalmenteVacunada": "poboación totalmente vacinada"
   }
+}


### PR DESCRIPTION
Este fix está relacionado al PR: [#134 - (Arreglado el título en catalán y otros idiomas)](https://github.com/midudev/covid-vacuna/pull/134)

Se han modificado los archivos i18n para recibir las "ccaa" como referencia a la traducción. Esto permitirá obtener los textos de forma correcta sin afectar el estado `filter` en home y en el componente `Table`.

He colocado la traducción para el país y Totales en cada idioma (Google Translate) para que se puedan visualizar los cambios. Pueden utilizar esta actualización en un futuro para colocar el nombre de cada comunidad con su respectiva traducción y/o corregir la traducción del país y Totales.

### Cambios menores

- Se le paso el linter a los archivos i18n.
- Se ha eliminado una alerta en la consola en referencia al `cellspacing` y `cellpadding`.
![table-warning](https://user-images.githubusercontent.com/79106418/107981345-4481c700-6f98-11eb-818b-bbb5dbee08d1.png)
