### PR TITLE
Añadido target _blank en enlaces de la versión embed

### DIFF
--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -101,7 +101,7 @@ export default function Table ({ data, filter, setFilter, reportFound }) {
 
   return (
     <div className={styles.container}>
-      <table className={styles.table} {...getTableProps()} border='0' cellspacing='0' cellpadding='0'>
+      <table className={styles.table} {...getTableProps()} border='0' cellSpacing='0' cellPadding='0'>
         <thead>
           {headerGroups.map(headerGroup => (
             <tr {...headerGroup.getHeaderGroupProps()}>

--- a/pages/como-incrustar.js
+++ b/pages/como-incrustar.js
@@ -34,7 +34,7 @@ export default function EjemploEmbed () {
 
         <h2>Copia este código</h2>
         <textarea
-          onChange={() => {}} onFocus={handleFocus} autoComplete='off' autoCapitalize='none' value='&lt;div style=&quot;position: relative; padding-bottom: 56.25%;&quot;&gt; &lt;iframe width=&quot;800&quot; height=&quot;450&quot; src=&quot;https://covid-vacuna.app/embed&quot; frameborder=&quot;0&quot; scrolling=&quot;no&quot; style=&quot;position: absolute; top: 0; left: 0; width: 100%; height: 100%;&quot; &gt;&lt;/iframe&gt; &lt;/div&gt;'
+          onChange={() => {}} onFocus={handleFocus} autoComplete='off' autoCapitalize='none' value='&lt;div style=&quot;position: relative; padding-bottom: 56.25%;&quot;&gt;&lt;iframe title=&quot;Información de vacunación en covid-vacuna.app&quot; width=&quot;800&quot; height=&quot;450&quot; src=&quot;https://covid-vacuna.app/embed&quot; frameborder=&quot;0&quot; scrolling=&quot;no&quot; style=&quot;position: absolute; top: 0; left: 0; width: 100%; height: 100%;&quot;&gt;&lt;/iframe&gt;&lt;/div&gt;'
         />
         <h2>Previsualización</h2>
         <p>Así es como quedará el embed en tu página web.</p>

--- a/pages/como-incrustar.js
+++ b/pages/como-incrustar.js
@@ -40,10 +40,11 @@ export default function EjemploEmbed () {
         <p>Así es como quedará el embed en tu página web.</p>
         <div id='pre-embed' style={{ position: 'relative', paddingBottom: '56.25%' }}>
           <iframe
+            title='Información de vacunación en covid-vacuna.app'
             width='800'
             height='450'
             src='https://covid-vacuna.app/embed'
-            frameborder='0'
+            frameBorder='0'
             scrolling='no'
             style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
           />

--- a/pages/embed.js
+++ b/pages/embed.js
@@ -72,11 +72,11 @@ export default function Embed ({ data, info, totalPopulation }) {
         </div>
 
         <small className={styles.description}>
-          Desarrollado por <strong><a href='https://midu.dev'>midudev</a></strong>
+          Desarrollado por <strong><a href='https://midu.dev' target='_blank' rel='noopener noreferrer'>midudev</a></strong>
         </small>
 
         <small className={styles.by}>
-          <a href='https://covid-vacuna.app'><strong>covid-vacuna.app</strong></a> - Datos actualizados <TimeAgo timestamp={info.lastModified} />
+          <a href='https://covid-vacuna.app' target='_blank' rel='nofollow noreferrer'><strong>covid-vacuna.app</strong></a> - Datos actualizados <TimeAgo timestamp={info.lastModified} />
         </small>
 
       </div>


### PR DESCRIPTION
- Añadido `target="_blank"` en los enlaces externos de la versión embed para evitar la navegación dentro del propio iframe
- Corregidos algunos nombres de atributos para que sean de estilo camelcase y evitar los warning de React en consola
- Añadido title al iframe del código embed para mejor accesibilidad