### PR TITLE
solución a la Issue #147

### DIFF
--- a/components/Table.jsx
+++ b/components/Table.jsx
@@ -39,7 +39,7 @@ export default function Table ({ data, filter, setFilter, reportFound }) {
         return {
           dosisPautaCompletada: !isNaN(dosisPautaCompletada) ? dosisPautaCompletada.toFixed(4) : 0,
           porcentajeEntregadas: porcentajeEntregadas !== null ? porcentajeEntregadas.toFixed(4) : 0,
-          porcentajePoblacionAdministradas: getPartialVacunationPopulation({ porcentajePoblacionAdministradas, porcentajePoblacionCompletas }),
+          porcentajePoblacionAdministradas: getPartialVacunationPopulation({ porcentajePoblacionAdministradas, porcentajePoblacionCompletas }).toFixed(4),
           porcentajePoblacionCompletas: porcentajePoblacionCompletas !== null ? porcentajePoblacionCompletas.toFixed(4) : 0,
           ...rest
         }


### PR DESCRIPTION
Como muestran en la issue 147 (https://github.com/midudev/covid-vacuna/issues/147) el sorting de la población vacunada tiene un error.

He visto que los otros valores decimales (que si que funcionan) se estan tratando con un `toFixed` y esto faltaba con la población vacunada. El screenshot que adjunto muestra el sorting correcto en esta PR.
![poblacion-vacunada](https://user-images.githubusercontent.com/30256079/108761078-b638b280-754e-11eb-8738-9444fd72f8c5.png)
