### PR TITLE
Unir las gráficas de dosis recibidas y administradas - Unificar graficas #43

### DIFF
--- a/components/ProgressChart/index.jsx
+++ b/components/ProgressChart/index.jsx
@@ -23,13 +23,20 @@ export default function ProgressChart ({ dataset, tooltip: CustomTooltip }) {
 
   if (!dataset) return null
 
+  // Join dosisAdministradas y dosisEntregadas to make an unique graph
+  const joinDataset = []
+  for (const data of dataset.dosisEntregadas) {
+    const valueAdministradas = dataset.dosisAdministradas.find(x => x.name === data.name)?.value
+    joinDataset.push({ name: data.name, ve: data.value, va: valueAdministradas })
+  }
+
   return (
     <div className={styles.chartContainer} ref={elementRef}>
       {isVisible && (
         <div style={{ width: '100%', height: 450 }}>
           <ResponsiveContainer>
             <AreaChart
-              data={dataset}
+              data={joinDataset}
               margin={{
                 top: 50,
                 right: 0,
@@ -48,9 +55,15 @@ export default function ProgressChart ({ dataset, tooltip: CustomTooltip }) {
               <Tooltip content={<CustomTooltip />} />
               <Area
                 type='monotone'
-                dataKey='value'
+                dataKey='ve'
                 stroke='var(--text-subtitle-color)'
                 fill='var(--app-shadow-color)'
+              />
+              <Area
+                type='monotone'
+                dataKey='va'
+                stroke='var(--app-selection-color)'
+                fill='var(--text-small-color)'
               />
             </AreaChart>
           </ResponsiveContainer>

--- a/components/ProgressChart/tooltips/index.jsx
+++ b/components/ProgressChart/tooltips/index.jsx
@@ -1,10 +1,13 @@
 import styles from '../styles/ProgressChart.module.css'
+import { useTranslate } from 'hooks/useTranslate'
 
 function formatNumberToLocale (payload, locale) {
   if (!payload) return
-
   const { value } = payload.pop()
+  return formatValueToLocale(value, locale)
+}
 
+function formatValueToLocale (value, locale) {
   const num = new Intl.NumberFormat(locale)
   return num.format(value)
 }
@@ -38,6 +41,24 @@ export function DosisEntregadasTooltip ({ active, payload, label }) {
       <p>
         A día <Bold text={label} /> se han entregado{' '}
         <Bold text={value} /> dosis.
+      </p>
+    </div>
+  )
+}
+
+export function DosisEntregadasVSAdministradasTooltip ({ active, payload, label }) {
+  const translate = useTranslate()
+
+  if (!active) return null
+  if (!payload) return null
+  const valueE = formatValueToLocale(payload[0].value, 'es-ES')
+  const valueA = formatValueToLocale(payload[1].value, 'es-ES')
+
+  return (
+    <div className={styles.chartTooltip}>
+      <p>
+        {translate.chart.aDia} <Bold text={label} /> {translate.chart.seHanEntregado}
+        <Bold text={valueE} />{translate.chart.dosisYSeHanAdministrado}<Bold text={valueA} />
       </p>
     </div>
   )

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,8 +26,7 @@ import styles from 'styles/Home.module.css'
 import useSearch from 'hooks/useSearchReport'
 import ProgressChart from 'components/ProgressChart'
 import {
-  DosisAdministradasTooltip,
-  DosisEntregadasTooltip
+  DosisEntregadasVSAdministradasTooltip
 } from 'components/ProgressChart/tooltips'
 import normalizeChartData from 'components/ProgressChart/utils/normalize-data'
 import { useTranslate } from 'hooks/useTranslate'
@@ -226,18 +225,11 @@ export default function Home ({ contributors, data, info, reports, chartDatasets
 
         <Table data={data} filter={filter} setFilter={setFilter} reportFound={reportFound} />
 
-        <h2 className={styles.subtitle}>{translate.home.evolucionDosisEntregadas}</h2>
+        <h2 className={styles.subtitle}>{translate.home.evolucionDosisEntregadasVSAdministradas}</h2>
 
         <ProgressChart
-          dataset={chartDatasets.dosisEntregadas}
-          tooltip={DosisEntregadasTooltip}
-        />
-
-        <h2 className={styles.subtitle}>{translate.home.evolucionDosisAdministradas}</h2>
-
-        <ProgressChart
-          dataset={chartDatasets.dosisAdministradas}
-          tooltip={DosisAdministradasTooltip}
+          dataset={chartDatasets}
+          tooltip={DosisEntregadasVSAdministradasTooltip}
         />
 
         <h2 className={styles.subtitle}>

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -25,6 +25,7 @@
       "poblacionTotalmenteVacunada": "% població totalment vacunada",
       "evolucionDosisEntregadas": "Evolució de dosis lliurades",
       "evolucionDosisAdministradas": "Evolució de dosis administrades",
+      "evolucionDosisEntregadasVSAdministradas": "Evolució de dosis entregades respecte a les administrades",
       "fuenteDatosEnlacesInteres": "Fonts de dades i enllaços d'interès",
       "fuente1": "Estratègia de Vacunació COVID-19 a Espanya",
       "fuente2": "Informació oficial sobre la vacunació contra el nou coronavirus",
@@ -86,5 +87,10 @@
         "sobreEntregadas": "sobre el total d'entregades",
         "poblacionVacunada": "població vacunada",
         "poblacionTotalmenteVacunada": "població totalment vacunada"
+    },
+    "chart": {
+        "aDia": "A dia ",
+        "seHanEntregado": " s'han entregat ",
+        "dosisYSeHanAdministrado": " dosis i s'han administrat "
     }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -26,6 +26,7 @@
         "poblacionTotalmenteVacunada": "% población totalmente vacunada",
         "evolucionDosisEntregadas": "Evolución de dosis entregadas",
         "evolucionDosisAdministradas": "Evolución de dosis administradas",
+        "evolucionDosisEntregadasVSAdministradas": "Evolución de dosis entregadas respecto a las administradas",
         "fuenteDatosEnlacesInteres": "Fuentes de datos y enlaces de interés",
         "fuente1": "Estrategia de Vacunación COVID-19 en España",
         "fuente2": "Información oficial sobre la vacunación contra el nuevo coronavirus",
@@ -87,5 +88,10 @@
         "sobreEntregadas": "sobre el total de entregadas",
         "poblacionVacunada": "población vacunada",
         "poblacionTotalmenteVacunada": "población totalmente vacunada"
+    },
+    "chart": {
+        "aDia": "A día ",
+        "seHanEntregado": " se han entregado ",
+        "dosisYSeHanAdministrado": " dosis y se han administrado "
     }
 }

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -25,6 +25,7 @@
       "poblacionTotalmenteVacunada": "% guztiz txertatutako populazioa",
       "evolucionDosisEntregadas": "Emandako dosien bilakaera",
       "evolucionDosisAdministradas": "Administratutako dosien bilakaera",
+      "evolucionDosisEntregadasVSAdministradas": "Emandako dosien bilakaera emandakoekin alderatuta",
       "fuenteDatosEnlacesInteres": "Datu iturriak eta esteka interesgarriak",
       "fuente1": "COVID-19 Txertaketa Estrategia Espainian",
       "fuente2": "Koronabirus berriaren aurkako txertoari buruzko informazio ofiziala",
@@ -86,5 +87,10 @@
         "sobreEntregadas": "entregatutako guztiaren gainean",
         "poblacionVacunada": "txertatutako populazioa",
         "poblacionTotalmenteVacunada": "guztiz txertatutako populazioa"
+    },
+    "chart": {
+        "aDia": "Egun bat ",
+        "seHanEntregado": " entregatu dute ",
+        "dosisYSeHanAdministrado": " dosiak eta eman zaizkie "
     }
   }

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -25,6 +25,7 @@
       "poblacionTotalmenteVacunada": "% poboación totalmente vacinada",
       "evolucionDosisEntregadas": "Evolución das doses entregadas",
       "evolucionDosisAdministradas": "Evolución das doses administradas",
+      "evolucionDosisEntregadasVSAdministradas": "Evolución das doses administradas en comparación coas administradas",
       "fuenteDatosEnlacesInteres": "Fontes de datos e ligazóns de interese",
       "fuente1": "Estratexia de vacinación COVID-19 en España",
       "fuente2": "Información oficial sobre a vacinación contra o novo coronavirus",
@@ -86,5 +87,10 @@
         "sobreEntregadas": "sobre o total entregado",
         "poblacionVacunada": "poboación vacinada",
         "poblacionTotalmenteVacunada": "poboación totalmente vacinada"
+    },
+    "chart": {
+        "aDia": "Un día ",
+        "seHanEntregado": " entregaron ",
+        "dosisYSeHanAdministrado": " doses e administráronse "
     }
   }


### PR DESCRIPTION
He resuelto la issue #43 uniendo las 2 gráficas para comparar fácilmente las dosis recibidas y las administradas.
![image](https://user-images.githubusercontent.com/9527475/109403339-fb008700-795c-11eb-81f4-4d1206bead29.png)
También he traducido el texto que aparece en el tooltip a los 4 idiomas que soporta la web.
Un saludo, espero ser de ayuda.