### PR TITLE
Pequeña mejora de accesibilidad en link de la descarga de JSON en dark mode

### DIFF
--- a/styles/DownloadData.module.css
+++ b/styles/DownloadData.module.css
@@ -2,11 +2,11 @@
   display: flex;
   align-items: center;
   font-size: 1rem;
-  color: #333;
+  color: var(--text-secondary-color);
   border-bottom: 1px dashed #ddd;
 }
 
 .download:hover {
-  color: #555;
+  color: var(--text-small-color);
   border-bottom: 1px dashed #09f;
 }


### PR DESCRIPTION
Hola!

He notado que en el dark-mode, en el link de descarga del JSON hay muy poco contraste con el fondo:

<img width="1655" alt="Captura de pantalla 2021-02-28 a las 11 41 53" src="https://user-images.githubusercontent.com/20989060/109415921-b5bf7200-79bb-11eb-93cb-9492e5907158.png">

En este PR se cambia el color de este link para mejorar la accesibilidad y mantener el mismo estilo que en el link que está debajo.

Muchas gracias por este pedazo de proyecto Midu,

Cualquier cosa me dices

Un saludo