### PR TITLE
Cambio de estilos para modo oscuro

### DIFF
--- a/components/Contributors.jsx
+++ b/components/Contributors.jsx
@@ -37,7 +37,7 @@ export default function Contributors ({ contributors }) {
       }
 
       a:hover {
-        box-shadow: rgb(210 239 253) 7px 7px;
+        box-shadow: var(--app-shadow-color) 7px 7px;
       }
     `}
       </style>

--- a/styles/I18nWidget.module.css
+++ b/styles/I18nWidget.module.css
@@ -12,7 +12,7 @@
   align-items: center;
   border: 1px solid #000000;
   background: #fff;
-  box-shadow: #92d5ff 1px 4px;
+  box-shadow: var(--app-shadow-color) 4px 4px;
   font-size: 0.7rem;
   font-weight: 500;
   display: flex;

--- a/styles/I18nWidget.module.css
+++ b/styles/I18nWidget.module.css
@@ -10,8 +10,9 @@
 
 .i18nWidget button {
   align-items: center;
-  border: 1px solid #000000;
-  background: #fff;
+  border: 1px solid var(--app-border-color);
+  color: var(--text-base-color);
+  background: var(--app-background-color);
   box-shadow: var(--app-shadow-color) 4px 4px;
   font-size: 0.7rem;
   font-weight: 500;
@@ -26,7 +27,7 @@
 
 .i18nWidget button:hover,
 .i18nWidget button:focus {
-  background-color: rgb(210, 237, 255);
+  background-color: var(--app-selection-color);
   box-shadow: none;
   transform: translate3d(4px, 4px, 0);
   transition: all 0.1s ease;

--- a/styles/I18nWidget.module.css
+++ b/styles/I18nWidget.module.css
@@ -41,9 +41,9 @@
 }
 
 .i18nWidget ul {
-  background-color: #fff;
+  background: var(--app-background-color);
   border-radius: 4px;
-  border: 1px solid #000;
+  border: 1px solid var(--app-border-color);
   padding: 0;
   top: 50px;
 }
@@ -56,7 +56,7 @@
 }
 
 .i18nWidget a {
-  color: #000;
+  color: var(--text-base-color);
   display: block;
   font-size: 0.7rem;
   font-weight: 500;
@@ -65,7 +65,7 @@
 }
 
 .i18nWidget a:hover {
-  background-color: rgb(210, 237, 255);
+  background-color: var(--app-selection-color);
 }
 
 

--- a/styles/SchemeColorSwitcher.module.css
+++ b/styles/SchemeColorSwitcher.module.css
@@ -2,7 +2,7 @@
   align-items: center;
   background: #fff;
   border-radius: 5000px;
-  box-shadow: 0 0 0px 1px #000, #92d5ff 4px 4px;
+  box-shadow: 0 0 0px 1px #000, var(--app-shadow-color) 4px 4px;
   display: flex;
   height: 26px;
   left: 32px;

--- a/styles/SchemeColorSwitcher.module.css
+++ b/styles/SchemeColorSwitcher.module.css
@@ -1,20 +1,19 @@
 .colorSwitch {
   align-items: center;
-  background: #fff;
+  border: 1px solid var(--app-border-color);
+  background: var(--app-background-color);
   border-radius: 5000px;
-  box-shadow: 0 0 0px 1px #000, var(--app-shadow-color) 4px 4px;
+  box-shadow: var(--app-shadow-color) 4px 4px;
   display: flex;
   height: 26px;
   left: 32px;
-  outline: 1px solid transparent;
   overflow: hidden;
   position: fixed;
   top: 16px;
 }
 
 .colorSwitch:hover {
-  background: rgb(210, 237, 255);
-  border: 1px solid #000000;
+  background: var(--app-selection-color);  border: 1px solid var(--app-border-color);
   box-shadow: none;
   transform: translate3d(4px, 4px, 0);
   transition: all 0.1s ease;

--- a/styles/Select.module.css
+++ b/styles/Select.module.css
@@ -8,7 +8,7 @@
   background: var(--app-background-color);
   border-radius: 5000px;
   border: 1px solid var(--app-border-color);
-  box-shadow: var(--app-shadow-color) 1px 4px;
+  box-shadow: var(--app-shadow-color) 4px 4px;
   margin-left: 8px;
   position: relative;
 }

--- a/styles/Share.module.css
+++ b/styles/Share.module.css
@@ -10,7 +10,7 @@
   background: #fff;
   border-radius: 50000px;
   border: 1px solid #000;
-  box-shadow: #92d5ff 4px 4px;
+  box-shadow: var(--app-shadow-color) 4px 4px;
   display: flex;
   font-size: .7rem;
   font-weight: 500;

--- a/styles/Share.module.css
+++ b/styles/Share.module.css
@@ -6,10 +6,10 @@
 
 .share a {
   align-items: center;
-  color: #000;
-  background: #fff;
+  color: var(--text-base-color);
+  background: var(--app-background-color);
   border-radius: 50000px;
-  border: 1px solid #000;
+  border: 1px solid var(--app-border-color);
   box-shadow: var(--app-shadow-color) 4px 4px;
   display: flex;
   font-size: .7rem;
@@ -20,7 +20,7 @@
 }
 
 .share a:hover {
-  background: rgb(210, 237, 255);
+  background: var(--app-selection-color);
   box-shadow: none;
   transform: translate3d(4px, 4px, 0);
   transition: all .1s ease;


### PR DESCRIPTION
He visto que algunos componentes tenían los colores estáticos en lugar de ser dinámicos en función de si estamos en modo oscuro o no. He modificado el color de fondo, de sombra y de borde del selector de color, del selector de idioma, del "Compártelo" y de los contribuidores.

Así el antes:
![Antes](https://user-images.githubusercontent.com/37581410/109886696-c9e7c580-7c80-11eb-9e69-982d38b0591f.png)

Así después:
![Despues](https://user-images.githubusercontent.com/37581410/109886738-dc61ff00-7c80-11eb-9c72-f0941219a97b.png)

Un saludo!