### PR TITLE
hotfix: Cambio en el ods del ministerio

### DIFF
--- a/components/EtariosBarChart/tooltips/index.jsx
+++ b/components/EtariosBarChart/tooltips/index.jsx
@@ -15,6 +15,9 @@ const EtariosBarChartToolTip = ({ active, payload, label }) => {
 
   if (!active) return null
   if (!payload) return null
+  if (!payload || !Array.isArray(payload) || payload.length < 3) {
+    return null
+  }
   const poblacionINE = formatValueToLocale(payload[0].value, 'es-ES')
   const unaDosis = formatValueToLocale(payload[1].value, 'es-ES')
   const unaDosisPorcentaje = `(${((100 * payload[1].value) / payload[0].value).toFixed(1)}%)`

--- a/scripts/transform-etarios-to-json.js
+++ b/scripts/transform-etarios-to-json.js
@@ -15,7 +15,8 @@ const transformEtariosToJson = (workbook) => {
 
 const transformEtariosToJsonFromWorkbook = (workbook) => {
   const { Sheets } = workbook
-  const [, , , Etarios1dosisKey, EtariosCompleteKey] = Object.keys(Sheets)
+  const Etarios1dosisKey = 'Etarios_con_al_menos_1_dosis'
+  const EtariosCompleteKey = 'Etarios_con_pauta_completa'
   const sheetEtarios1dosis = Sheets[Etarios1dosisKey]
   const sheetEtariosComplete = Sheets[EtariosCompleteKey]
   const unaDosis = etariosMapByCCAA(XLSX.utils.sheet_to_json(sheetEtarios1dosis), 'unaDosis')


### PR DESCRIPTION
El ministerio ha decidido meter una pestaña nueva en el ods en medio lo cual ha roto la lectura de etarios. He cambiado la estrategia y uso el nombre concreto de cada sheet. Lógicamente esto podría volver a romper si les da por cambiar el nombre de la pestaña. No obstante parece que en cuanto a textos está siendo bastante estable.

De paso he añadido una línea para que si vuelve a fallar la captura de etarios evite que rompa la página (estaba pasando)