### PR TITLE
Cambio de 'vacunada' a 'con al menos una dosis' en el componente de progreso

### DIFF
--- a/public/i18n/ast.json
+++ b/public/i18n/ast.json
@@ -54,7 +54,7 @@
         }
     },
     "progress": {
-        "verPoblacionVacunada": "Población vacunada",
+        "verPoblacionVacunada": "Población con al menos una dosis",
         "verPoblacionConPauta": "Población con vacunada dafechu",
         "estimacionPoblacionVacunada": "Estimación población vacunada",
         "noDatos": "Nun hai datos pa esa fecha."

--- a/public/i18n/ca.json
+++ b/public/i18n/ca.json
@@ -54,7 +54,7 @@
       }
     },
     "progress": {
-      "verPoblacionVacunada": "Població vacunada",
+      "verPoblacionVacunada": "Població amb almenys una dosi",
       "verPoblacionConPauta": "Població amb pauta completa",
       "estimacionPoblacionVacunada": "Estimació població vacunada",
       "noDatos": "No disposem de dades per a aquesta data."

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -54,7 +54,7 @@
         }
     },
     "progress": {
-        "verPoblacionVacunada": "Población vacunada",
+        "verPoblacionVacunada": "Población con al menos una dosis",
         "verPoblacionConPauta": "Población con pauta completa",
         "estimacionPoblacionVacunada": "Estimación población vacunada",
         "noDatos": "No disponemos de datos para esa fecha."

--- a/public/i18n/eu.json
+++ b/public/i18n/eu.json
@@ -54,7 +54,7 @@
     }
   },
   "progress": {
-    "verPoblacionVacunada": "Txertatutako populazioa",
+    "verPoblacionVacunada": "Gutxienez dosi bat duten populazioa",
     "verPoblacionConPauta": "Populazioa jarraibide osoekin",
     "estimacionPoblacionVacunada": "Txertatutako biztanleriaren estimazioa",
     "noDatos": "Ez dugu data horretarako daturik."

--- a/public/i18n/gl.json
+++ b/public/i18n/gl.json
@@ -54,7 +54,7 @@
     }
   },
   "progress": {
-    "verPoblacionVacunada": "Poboación vacinada",
+    "verPoblacionVacunada": "Poboación con polo menos unha dose",
     "verPoblacionConPauta": "Poboación con pauta completa",
     "estimacionPoblacionVacunada": "Estimación da poboación vacinada",
     "noDatos": "Non dispoñemos de datos para esa data."


### PR DESCRIPTION
He modificado el texto de "Población vacunada" por "Población con al menos una dosis" como se comenta en la Issue #191 para que quede más claro a que se refiere ese porcentaje.