### PR TITLE
Share URL for the current language

### DIFF
--- a/components/Share.jsx
+++ b/components/Share.jsx
@@ -4,7 +4,7 @@ import styles from 'styles/Share.module.css'
 export default function Share () {
   const translate = useTranslate()
   const params = new URLSearchParams({
-    url: 'https://covid-vacuna.app',
+    url: window.location.href,
     text: translate.share.textParamUrl
   })
 


### PR DESCRIPTION
Hi,

When you share an URL on Twitter, the text is something like:

`Segueix el progrés de la vacunació contra el COVID19 en aquesta web creada per @midudev!  https://covid-vacuna.app`

I think it should share the current language too, something like:

`Segueix el progrés de la vacunació contra el COVID19 en aquesta web creada per @midudev! https://covid-vacuna.app/ca`

I can't test the web because some errors in my system (I tried in 2 PCs), please, check if the change is correct.

Thank you!! 