### PR TITLE
Eliminar previsión del 50%

### DIFF
--- a/components/Prevision.jsx
+++ b/components/Prevision.jsx
@@ -23,9 +23,6 @@ const addDaysToInitialData = (days) => {
 }
 
 const points = [{
-  color: '#dd8f01',
-  percentage: 50
-}, {
   color: '#a3dd01',
   percentage: 75
 }, {


### PR DESCRIPTION
Hola,

como probablemente el lunes de la semana que viene hayamos alcanzado el 50% de población con pauta completa he eliminado esa previsión y he dejado la del 75% y 100%.

Ya queda menos!