### PR TITLE
Corrección para que muestre previsión de 50-75-100 % según corresponda

### DIFF
--- a/components/Prevision.jsx
+++ b/components/Prevision.jsx
@@ -22,14 +22,6 @@ const addDaysToInitialData = (days) => {
   return new Date(initialData)
 }
 
-const points = [{
-  color: '#a3dd01',
-  percentage: 75
-}, {
-  color: '#41ca0d',
-  percentage: 100
-}]
-
 export default function Prevision ({ totals }) {
   const { locale } = useLocale()
   const translate = useTranslate()
@@ -40,26 +32,50 @@ export default function Prevision ({ totals }) {
       days,
       totals.porcentajePoblacionAdministradas - totals.porcentajePoblacionCompletas
     )
-
+  const points = [
+    {
+      color: '#dd8f01',
+      percentage: 50,
+      show: !((totals.porcentajePoblacionCompletas >= 0.50))
+    },
+    {
+      color: '#a3dd01',
+      percentage: 75,
+      show: !((totals.porcentajePoblacionCompletas >= 0.75))
+    },
+    {
+      color: '#41ca0d',
+      percentage: 100,
+      show: !((totals.porcentajePoblacionCompletas >= 1))
+    }]
   return (
     <>
       <h2>{translate.progress.estimacionPoblacionVacunada}</h2>
-      {totals.porcentajePoblacionCompletas
+      {totals.porcentajePoblacionCompletas && totals.porcentajePoblacionCompletas < 1
         ? (
           <section>
             {
-          points.map(({ color, percentage }) => (
-            <div className='card' key={percentage}>
-              <span style={{ '--color': color }}>{percentage}%</span>
-              <time>{intl.format(addDaysToInitialData(getDays(percentage)))}</time>
-            </div>
+          points.map(({ color, percentage, show }) => (
+            show &&
+              <div className='card' key={percentage}>
+                <span style={{ '--color': color }}>{percentage}%</span>
+                <time>{intl.format(addDaysToInitialData(getDays(percentage)))}</time>
+              </div>
           ))
         }
           </section>)
         : (
-          <p>
-            <b>{translate.progress.noDatos}</b>
-          </p>
+            totals.porcentajePoblacionCompletas >= 1
+              ? (
+                <h1>
+                  TODOS VACUNADOS
+                </h1>
+                )
+              : (
+                <p>
+                  <b>{translate.progress.noDatos}</b>
+                </p>
+                )
           )}
 
       <style jsx>{`


### PR DESCRIPTION
Hola midu, con esto tenes que olvidarte de ir editando el componente Prevision y quitarle los points, 50% 75% 100% a mano, además te queda bien según la comunidad autónoma como vaya avanzando, si una ya lleva el 89% pues a esa puntual no se le mostrara la card de la previsión del 75%.
Te dejo imágenes, con datos modificados (en el latest.json) para que vea como se comporta en cada situación.

Con los siguientes supuestos:
![1](https://user-images.githubusercontent.com/49108644/128599085-32dc7b22-0273-41cb-9148-1973467e9b2d.png)

se vería así en cada comunidad:
![2](https://user-images.githubusercontent.com/49108644/128599105-e358b3cf-8e78-47ec-86b7-4b403b6d2fbb.png)

![21](https://user-images.githubusercontent.com/49108644/128599108-ae8facb6-c511-48f2-a7d7-2065353f23f0.png)

![3](https://user-images.githubusercontent.com/49108644/128599109-e4d52af3-8b6c-43fc-829b-98a2a4affee7.png)

![4](https://user-images.githubusercontent.com/49108644/128599116-2629cbfa-fbcb-4616-bd74-5cea2882b8bc.png)

El primer caso no le aplica ya a España, pero bueno lo dejo por las dudas.


