### PR TITLE
Fix en el cálculo de días para llegar a un porcentaje

### DIFF
--- a/components/Prevision.jsx
+++ b/components/Prevision.jsx
@@ -30,7 +30,7 @@ export default function Prevision ({ totals }) {
   const getDays = (days) =>
     getDaysToAchievePercentage(
       days,
-      totals.porcentajePoblacionAdministradas - totals.porcentajePoblacionCompletas
+      totals.porcentajePoblacionPrimeraDosis || (totals.porcentajePoblacionAdministradas - totals.porcentajePoblacionCompletas)
     )
   const points = [
     {


### PR DESCRIPTION
Para la previsión se está calculando el porcentaje de población con primera dosis mediante la resta del total de dosis administradas menos las segundas dosis. Esto con la llegada de Janssen que solo tiene una dosis es un error y está provocando que la previsión sea muy mala.

Desde hace unos meses está disponible el valor de población con primera dosis, así que he usado ese valor cuando esté disponible, y el cálculo antiguo cuando no.