### PR TITLE
fixed problem running scripts from windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "node": "14.x"
   },
   "scripts": {
-    "analyze": "NODE_ICU_DATA=node_modules/full-icu ANALYZE=true next build",
-    "build": "NODE_ICU_DATA=node_modules/full-icu next build",
-    "dev": "NODE_ICU_DATA=node_modules/full-icu next dev",
+    "analyze": "cross-env NODE_ICU_DATA=node_modules/full-icu ANALYZE=true next build",
+    "build": "cross-env NODE_ICU_DATA=node_modules/full-icu next build",
+    "dev": "cross-env NODE_ICU_DATA=node_modules/full-icu next dev",
     "start": "next start",
     "export": "next export",
     "download-today-status": "node scripts/download-covid-vaccine-today-status.js",
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "12.0.1",
+    "cross-env": "^7.0.3",
     "eslint": "7.23.0",
     "eslint-config-next": "12.0.1",
     "standard": "16.0.4"


### PR DESCRIPTION
I had a problem running the npm scripts from my machine:

```
os: Windows 10
npm: 8.6.0
NodeJS: 16.14.2
```

The error was the following
![image](https://user-images.githubusercontent.com/14883509/194672105-c492ecdb-1d61-4fa9-8309-d713c7185423.png)

I added cross-env library to fix this problem and now is working correctly from my machine.